### PR TITLE
Try out --changed

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,6 +6,9 @@
   "files": {
     "ignore": ["**/dist/**"]
   },
+  "vcs": {
+    "defaultBranch": "main"
+  },
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "del \"**/dist\" && vitepress build && cp _redirects .vitepress/dist",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "preview": "vitepress preview"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "build:clean": "del dist",
     "build:ts": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:license": "node ../../scripts/inject-license.js @cobalt-ui/core dist/index.js",
     "dev": "pnpm run --parallel \"/^dev:.*/\"",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "dev:ts": "tsc -p tsconfig.build.json --watch",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",

--- a/packages/lint-a11y/package.json
+++ b/packages/lint-a11y/package.json
@@ -36,7 +36,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:license": "node ../../scripts/inject-license.js @cobalt-ui/lint-a11y dist/index.js",
     "dev": "tsc -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -31,7 +31,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:license": "node ../../scripts/inject-license.js @cobalt-ui/plugin-css dist/index.js",
     "dev": "tsc -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"

--- a/packages/plugin-js/package.json
+++ b/packages/plugin-js/package.json
@@ -30,7 +30,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:license": "node ../../scripts/inject-license.js @cobalt-ui/plugin-js dist/index.js",
     "dev": "tsc -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "co build -c ./test/types.tokens.mjs && pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -31,7 +31,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:license": "node ../../scripts/inject-license.js @cobalt-ui/plugin-sass dist/index.js",
     "dev": "tsc -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -30,7 +30,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:license": "node ../../scripts/inject-license.js @cobalt-ui/plugin-tailwind dist/index.js",
     "dev": "tsc  -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "del dist && tsc -p tsconfig.build.json",
     "dev": "tsc  -p tsconfig.build.json -w",
-    "lint": "biome check .",
+    "lint": "biome check --changed .",
     "test": "pnpm run \"/^test:.*/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit"


### PR DESCRIPTION
## Changes

Tries out lint ratcheting with `--changed`. It’s a neat idea, turning CI from erring on all failures, to **only failing on regressions.** The reason you’d want to catch regressions is the default settings often **discourage tightening lint rules** because whoever changes the lint rule has to change the entire codebase (even sometimes requiring code refactoring).

But with `--changed`, lint rules can be enforced from a certain point onward, and catch new regressions while letting you slowly chip away at the existing issues over time. It’s the best of both worlds—it encourages increasingly-tightening your linting, without punishing you for existing violations in a working codebase.

## How to Review

- Chore; only changes the linter
