### PR TITLE
Make unpublished packages temporarily private

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,13 +4,5 @@
   "commit": false,
   "linked": [["@terrazzo/cli", "@terrazzo/parser"]],
   "access": "public",
-  "baseBranch": "main",
-  "ignore": [
-    "@terrazzo/monorepo",
-    "@terrazzo/plugin-lint-a11y",
-    "@terrazzo/plugin-tailwind",
-    "@terrazzo/storybook",
-    "@terrazzo/token-lab",
-    "@terrazzo/www"
-  ]
+  "baseBranch": "main"
 }

--- a/packages/plugin-lint-a11y/package.json
+++ b/packages/plugin-lint-a11y/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@terrazzo/plugin-lint-a11y",
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "description": "Add accessibility linting checks for your DTCG design tokens",
   "keywords": [

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@terrazzo/plugin-tailwind",
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "author": {
     "name": "Drew Powers",


### PR DESCRIPTION
## Changes

- Adds `private: true` to temporarily-unpublished packages that haven’t been built yet. Fixes dependency error Changesets was throwing

## How to Review

- Tested manually
