### PR TITLE
fix(@terrazzo/token-tools): remove StringToken duplicated declaration in Token type

### DIFF
--- a/packages/token-tools/src/types.ts
+++ b/packages/token-tools/src/types.ts
@@ -19,7 +19,6 @@ export type Token =
   | NumberToken
   | ShadowToken
   | StringToken
-  | StringToken
   | TransitionToken
   | TypographyToken
   | StrokeStyleToken;


### PR DESCRIPTION
## Changes

Removes the `StringToken` declared  twice within the `Token` union type in `token-tools/src/types.ts`.

## How to Review

I don't expect this change to have any side effect.
