### PR TITLE
Improve alias validation for composite types

### DIFF
--- a/.changeset/loud-kings-prove.md
+++ b/.changeset/loud-kings-prove.md
@@ -1,0 +1,6 @@
+---
+"@terrazzo/parser": patch
+"@terrazzo/cli": patch
+---
+
+Fix bug in gradient position aliasing

--- a/.changeset/polite-clouds-remain.md
+++ b/.changeset/polite-clouds-remain.md
@@ -1,0 +1,6 @@
+---
+"@terrazzo/parser": patch
+"@terrazzo/cli": patch
+---
+
+Improve alias type validation

--- a/packages/parser/logger.js
+++ b/packages/parser/logger.js
@@ -25,8 +25,12 @@ export function formatMessage(entry, severity) {
   }
   if (entry.src) {
     const start = entry.node?.loc?.start;
-    // note: strip "file://" protocol, but not href
-    message = `${message}\n\n${entry.filename ? `${entry.filename.href.replace(/^file:\/\//, '')}:${start?.line ?? 0}:${start?.column ?? 0}\n\n` : ''}${codeFrameColumns(entry.src, { start }, { highlightCode: false })}`;
+    //  strip "file://" protocol, but not href
+    const loc = entry.filename
+      ? `${entry.filename?.href.replace(/^file:\/\//, '')}:${start?.line ?? 0}:${start?.column ?? 0}\n\n`
+      : '';
+    const codeFrame = codeFrameColumns(entry.src, { start }, { highlightCode: false });
+    message = `${message}\n\n${loc}${codeFrame}`;
   }
   return message;
 }

--- a/packages/parser/parse/normalize.js
+++ b/packages/parser/parse/normalize.js
@@ -73,7 +73,7 @@ export default function normalizeValue(token) {
       for (let i = 0; i < token.$value.length; i++) {
         const stop = { ...token.$value[i] };
         stop.color = normalizeValue({ $type: 'color', $value: stop.color });
-        if (typeof stop.position !== 'number') {
+        if (stop.position === undefined) {
           stop.position = i / (token.$value.length - 1);
         }
         output.push(stop);

--- a/packages/parser/parse/validate.d.ts
+++ b/packages/parser/parse/validate.d.ts
@@ -12,7 +12,7 @@ export interface ValidateOptions {
   logger: Logger;
 }
 
-export function validateAlias($value: ValueNode, node: AnyNode, options: ValidateOptions): void;
+export function validateAliasSyntax($value: ValueNode, node: AnyNode, options: ValidateOptions): void;
 
 export function validateBorder($value: ValueNode, node: AnyNode, options: ValidateOptions): void;
 

--- a/packages/parser/parse/validate.js
+++ b/packages/parser/parse/validate.js
@@ -92,7 +92,7 @@ function validateMembersAs($value, properties, node, { filename, src, logger }) 
     }
     const value = members[property];
     if (isMaybeAlias(value)) {
-      validateAlias(value, node, { filename, src, logger });
+      validateAliasSyntax(value, node, { filename, src, logger });
     } else {
       validator(value, node, { filename, src, logger });
     }
@@ -100,13 +100,13 @@ function validateMembersAs($value, properties, node, { filename, src, logger }) 
 }
 
 /**
- * Verify an Alias token is valid
+ * Verify an Alias $value is formatted correctly
  * @param {ValueNode} $value
  * @param {AnyNode} node
  * @param {ValidateOptions} options
  * @return {void}
  */
-export function validateAlias($value, node, { filename, src, logger }) {
+export function validateAliasSyntax($value, node, { filename, src, logger }) {
   if ($value.type !== 'String' || !isAlias($value.value)) {
     logger.error({ message: `Invalid alias: ${print($value)}`, filename, node: $value, src });
   }
@@ -476,7 +476,7 @@ export function validateStrokeStyle($value, node, { filename, src, logger }) {
       for (const element of dashArray.elements) {
         if (element.value.type === 'String' && element.value.value !== '') {
           if (isMaybeAlias(element.value)) {
-            validateAlias(element.value, node, { logger, src });
+            validateAliasSyntax(element.value, node, { logger, src });
           } else {
             validateDimension(element.value, node, { logger, src });
           }
@@ -550,7 +550,7 @@ export default function validate(node, { filename, src, logger }) {
   // If top-level value is a valid alias, this is valid (no need for $type)
   // ⚠️ Important: ALL Object and Array nodes below will need to check for aliases within!
   if (isMaybeAlias($value)) {
-    validateAlias($value, node, { logger, src });
+    validateAliasSyntax($value, node, { logger, src });
     return;
   }
 

--- a/packages/parser/test/parse.test.ts
+++ b/packages/parser/test/parse.test.ts
@@ -330,7 +330,7 @@ font:
             },
           ],
           want: {
-            error: `Alias "{color.base.blue.600}" not found
+            error: `Alias "{color.base.blue.600}" not found.
 
 /tokens.json:11:17
 
@@ -364,7 +364,7 @@ font:
             },
           ],
           want: {
-            error: `Alias "{color.base.blue.600}" not found
+            error: `Alias "{color.base.blue.600}" not found.
 
 /b.json:2:15
 
@@ -443,7 +443,7 @@ font:
             },
           ],
           want: {
-            error: `Circular alias detected from "{color.text.primary}"
+            error: `Circular alias detected from "{color.text.primary}".
 
 /tokens.json:4:16
 
@@ -454,6 +454,162 @@ font:
   5 |       "$value": "{color.text.primary}"
   6 |     },
   7 |     "text": {`,
+          },
+        },
+      ],
+      [
+        'invalid: wrong type (root)',
+        {
+          given: [
+            {
+              filename: DEFAULT_FILENAME,
+              src: {
+                dimension: {
+                  base: { $type: 'dimension', $value: '1rem' },
+                },
+                border: {
+                  base: {
+                    $type: 'border',
+                    $value: '{dimension.base}',
+                  },
+                },
+              },
+            },
+          ],
+          want: {
+            error: `Invalid alias: expected $type: "border", received $type: "dimension".
+
+/tokens.json:11:17
+
+   9 |     "base": {
+  10 |       "$type": "border",
+> 11 |       "$value": "{dimension.base}"
+     |                 ^
+  12 |     }
+  13 |   }
+  14 | }`,
+          },
+        },
+      ],
+      [
+        'invalid: wrong type (composite)',
+        {
+          given: [
+            {
+              filename: DEFAULT_FILENAME,
+              src: {
+                color: {
+                  $type: 'color',
+                  blue: {
+                    $value: '#10109a',
+                  },
+                },
+                stroke: {
+                  $type: 'strokeStyle',
+                  solid: { $value: 'solid' },
+                },
+                border: {
+                  nested: {
+                    $type: 'border',
+                    $value: {
+                      color: '{color.blue}',
+                      width: '{color.blue}',
+                      style: '{stroke.solid}',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          want: {
+            error: `Invalid alias: expected $type: "dimension", received $type: "color".
+
+/tokens.json:19:18
+
+  17 |       "$value": {
+  18 |         "color": "{color.blue}",
+> 19 |         "width": "{color.blue}",
+     |                  ^
+  20 |         "style": "{stroke.solid}"
+  21 |       }
+  22 |     }`,
+          },
+        },
+      ],
+      [
+        'invalid: wrong type (composite array)',
+        {
+          given: [
+            {
+              filename: DEFAULT_FILENAME,
+              src: {
+                color: {
+                  $type: 'color',
+                  blue: { $value: '#10109a' },
+                },
+                stop: {
+                  $type: 'number',
+                  0: { $value: 0.5 },
+                },
+                duration: {
+                  $type: 'duration',
+                  s: { $value: '100ms' },
+                },
+                gradient: {
+                  base: {
+                    $type: 'gradient',
+                    $value: [
+                      { color: '{color.blue}', position: '{stop.0}' },
+                      { color: '{color.blue}', position: '{duration.s}' },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+          want: {
+            error: `Invalid alias: expected $type: "number", received $type: "duration".
+
+/tokens.json:30:23
+
+  28 |         {
+  29 |           "color": "{color.blue}",
+> 30 |           "position": "{duration.s}"
+     |                       ^
+  31 |         }
+  32 |       ]
+  33 |     }`,
+          },
+        },
+      ],
+      [
+        'invalid: wrong type (strokeStyle)',
+        {
+          given: [
+            {
+              filename: DEFAULT_FILENAME,
+              src: {
+                dimension: { $type: 'dimension', s: { $value: '0.5rem' } },
+                number: { $type: 'number', 50: { $value: 50 } },
+                strokeStyle: {
+                  $type: 'strokeStyle',
+                  dashed: { $value: { dashArray: ['{dimension.s}', '{number.50}'], lineCap: 'round' } },
+                },
+              },
+            },
+          ],
+          want: {
+            error: `Invalid alias: expected $type: "dimension", received $type: "number".
+
+/tokens.json:20:11
+
+  18 |         "dashArray": [
+  19 |           "{dimension.s}",
+> 20 |           "{number.50}"
+     |           ^
+  21 |         ],
+  22 |         "lineCap": "round"
+  23 |       }`,
           },
         },
       ],
@@ -1842,6 +1998,54 @@ font:
   10 |         "color": "#ff9900"
   11 |       }
   12 |     ]`,
+          },
+        },
+      ],
+    ];
+
+    it.each(tests)('%s', (_, testCase) => runTest(testCase));
+  });
+
+  describe('9.7 Typography', () => {
+    const tests: Test[] = [
+      [
+        'valid',
+        {
+          given: [
+            {
+              filename: DEFAULT_FILENAME,
+              src: {
+                typography: {
+                  $type: 'typography',
+                  $value: {
+                    fontFamily: 'Helvetica',
+                    fontSize: '16px',
+                    fontStyle: 'italic',
+                    fontVariant: 'small-caps',
+                    fontWeight: 400,
+                    letterSpacing: '0.1px',
+                    lineHeight: 1.5,
+                    textDecoration: 'underline',
+                    textTransform: 'uppercase',
+                  },
+                },
+              },
+            },
+          ],
+          want: {
+            tokens: {
+              typography: {
+                fontFamily: 'Helvetica',
+                fontSize: '16px',
+                fontStyle: 'italic',
+                fontVariant: 'small-caps',
+                fontWeight: 400,
+                letterSpacing: '0.1px',
+                lineHeight: 1.5,
+                textDecoration: 'underline',
+                textTransform: 'uppercase',
+              },
+            },
           },
         },
       ],


### PR DESCRIPTION
## Changes

Fixes #309. Adds tests and catches validation errors for aliasing composite types. Also fixes a bug in `$type: gradient` dealing with nested aliases.

## How to Review

- Tests added; tests should pass
- This is just a bugfix
