### PR TITLE
CI: Reduce number of runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,36 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x, 22.x, 23.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.2
+          run_install: true
+      - run: pnpm test
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.2
+          run_install: true
+      - run: pnpm test
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
       - uses: pnpm/action-setup@v4
         with:
           version: 9.12.2


### PR DESCRIPTION
## Changes

Move from a Node version × OS strategy, to testing Node versions on Linux and only 1 macOS/Windows run per each.

## How to Review

- CI should pass
