### PR TITLE
fix(cli): tz command annot be executed by spawn

### DIFF
--- a/.changeset/new-tools-attack.md
+++ b/.changeset/new-tools-attack.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/cli": patch
+---
+
+Fix npm error when invoking the Terrazzo CLI through npm

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * @module @terrazzo/cli
  * @license MIT License


### PR DESCRIPTION
## Changes

This PR addresses the issue mentioned in #349. I have run into the same problems for a while now and just kept using Cobalt UI until today. I would usually call `tz build` in a npm script, which runs into the same problem as described in #349. Debugging the script call in VS Code reveals that npm is throwing the error and not Terrazzo (see screenshot).

![Debug stack trace of calling Terrazzo](https://github.com/user-attachments/assets/cebe2ced-b82d-48a8-9e7d-0311dd3702bb)

I managed to fix it by adding the shebang specifier (not sure if that is the name) from the Cobalt UI CLI to the Terrazzo CLI script, where it has been missing until now.


## How to Review

Try to invoke the Terrazzo CLI through an npm script in a project. It should succedd with this PR.

I am not sure, how this can be tested. All CLI tests seem to invoke the script directly through Node.js. However, testing this requires the test to invoke the built package through npm, right? Is this possible with the current test setup? Does this need a test?

closes #349 