### PR TITLE
Add Microsoft Fluent

### DIFF
--- a/.changeset/khaki-pandas-yawn.md
+++ b/.changeset/khaki-pandas-yawn.md
@@ -1,0 +1,7 @@
+---
+"@terrazzo/cli": patch
+"@terrazzo/parser": patch
+"@terrazzo/token-tools": patch
+---
+
+Add Microsoft Fluent as starter template

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -26,6 +26,7 @@ type DesignSystem =
   | 'figma-sds'
   | 'github-primer'
   | 'ibm-carbon'
+  | 'microsoft-fluent'
   | 'radix'
   | 'salesforce-lightning'
   | 'shopify-polaris';
@@ -56,6 +57,11 @@ const DESIGN_SYSTEMS: Record<DesignSystem, { name: string; author: string; token
     name: 'Carbon',
     author: 'IBM',
     tokens: ['ibm-carbon.json'],
+  },
+  'microsoft-fluent': {
+    name: 'Fluent',
+    author: 'Microsoft',
+    tokens: ['microsoft-fluent.json'],
   },
   radix: {
     name: 'Radix',


### PR DESCRIPTION
## Changes

Adds the Microsoft Fluent v2 design system as an option for `tz init`

## How to Review

- N/A
