### PR TITLE
CLI init Fix spinner

### DIFF
--- a/.changeset/cold-poems-doubt.md
+++ b/.changeset/cold-poems-doubt.md
@@ -1,0 +1,7 @@
+---
+"@terrazzo/cli": patch
+"@terrazzo/parser": patch
+"@terrazzo/token-tools": patch
+---
+
+Fix tz init spinner


### PR DESCRIPTION
## Changes

![CleanShot 2024-11-29 at 08 26 43](https://github.com/user-attachments/assets/4c36eb08-a425-4fa3-a272-b95537498c25)

Spinner on `tz init` would get stuck installing packages. Also fixes stacked ellipses.

## How to Review

N/A