### PR TITLE
Don’t parse values in $extensions

### DIFF
--- a/.changeset/cyan-ties-collect.md
+++ b/.changeset/cyan-ties-collect.md
@@ -1,0 +1,7 @@
+---
+"@terrazzo/parser": patch
+"@terrazzo/cli": patch
+"@terrazzo/token-tools": patch
+---
+
+Ignore token-like structures inside $extensions

--- a/packages/parser/src/parse/index.ts
+++ b/packages/parser/src/parse/index.ts
@@ -259,7 +259,10 @@ async function parseSingle(
 
         const id = path.join('.');
 
-        if (members.$value) {
+        if (
+          members.$value &&
+          !path.includes('$extensions') // don’t validate anything in $extensions
+        ) {
           const extensions = members.$extensions ? getObjMembers(members.$extensions as ObjectNode) : undefined;
           const sourceNode = structuredClone(node);
 

--- a/packages/parser/test/parse.test.ts
+++ b/packages/parser/test/parse.test.ts
@@ -2648,4 +2648,38 @@ describe('Additional cases', () => {
       }
     });
   });
+
+  describe('$extensions', () => {
+    const tests: [string, { given: any; want: any }][] = [
+      [
+        '$value is ignored',
+        {
+          given: [
+            {
+              filename: DEFAULT_FILENAME,
+              src: {
+                emptyGroup: { $extensions: { foo: { $value: 'bar' } } },
+                color: {
+                  $type: 'color',
+                  blue: { $value: { colorSpace: 'srgb', channels: [0.2, 0.4, 0.8], alpha: 1 } },
+                  $extensions: { fake: { $value: 'foo' } },
+                },
+              },
+            },
+          ],
+          want: {
+            'color.blue': { alpha: 1, channels: [0.2, 0.4, 0.8], colorSpace: 'srgb' },
+          },
+        },
+      ],
+    ];
+
+    it.each(tests)('%s', async (_, { given, want }) => {
+      const config = defineConfig({}, { cwd });
+      const { tokens } = await parse(given, { config });
+      for (const id in want) {
+        expect(tokens[id]!.$value).toEqual(want[id]);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Fix #363. Don’t validate anything inside `$extensions` (even if they look like valid tokens).

## How to Review

- Tests added to catch future regressions
