### PR TITLE
fix color picker documentation layout for mobile

### DIFF
--- a/packages/tiles/src/Demo/Demo.css
+++ b/packages/tiles/src/Demo/Demo.css
@@ -1,15 +1,13 @@
 .tz-demo {
-  display: flex;
+  display: grid;
 }
 
 .tz-demo-canvas {
-  flex: 1 1 auto;
   padding: var(--tz-space-400);
 }
 
 .tz-demo-code {
-  flex: 1 1 auto;
-  position: relative;
+  contain: inline-size;
 }
 
 .tz-demo-code-copy-wrapper {


### PR DESCRIPTION
## Changes
- Updates the color picker page which is janked on mobile.
- One of the code example components was taking up more width than the viewport creating a horizontal scrolling.
- Switched it to vertical stack, since even on desktop the source code overlapped with the rendered component.
- The last code group on the page is still problematic for layout (notice how the page always zoomed in in the after video). It is widening its parent element and stretching all its siblings with it.

### Before

https://github.com/user-attachments/assets/d29f6451-e646-4eae-a69d-2daa38622cc6

### After

https://github.com/user-attachments/assets/c2216df0-315c-491f-bcf1-4e06d9025e4e

## How to Review

Where else might the tiles package be being used?