### PR TITLE
fix(color picker): sliders cant be dragged with touch

### DIFF
--- a/packages/tiles/src/Slider/Slider.css
+++ b/packages/tiles/src/Slider/Slider.css
@@ -42,7 +42,7 @@
   padding: 0;
   position: absolute;
   top: 50%;
-  touch-action: pan-x;
+  touch-action: none;
   transform: translate3d(var(--tz-slider-handle-position), -50%, 0);
   width: var(--tz-slider-handle-size);
   z-index: calc(var(--tz-layer-base) + 1);


### PR DESCRIPTION
## Changes
- Prevents browsers from taking away the stream of pointer events from the slider element by adding `touch-action: none`.
- This property is generally unnecessary if the pointer stream is locked to the element with `setPointerCapture`, or if the element is naturally draggable like range inputs (I went through this whole rigamarole wjth the color picker on [sillystring.party](https://sillystring.party).)
- useDrag has a pointer.capture option, which the docs imply is on by default, but it doesnt have the effect, even when set explicitly.

### Before

https://github.com/user-attachments/assets/8c4ae9f6-b259-4fa0-9e63-0e13c77facbd



### After

https://github.com/user-attachments/assets/923c8358-2004-4991-a16e-e5395a64eade



## How to Review

Thoroughly. Don't miss a line.