### PR TITLE
fix(website): prevent viewport leak

### DIFF
--- a/www/src/styles/docs.css
+++ b/www/src/styles/docs.css
@@ -200,7 +200,10 @@
   }
 
   table {
+    display: block;
     border-collapse: collapse;
+    overflow-x: scroll;
+    contain: inline-size;
   }
 
   th {
@@ -345,6 +348,7 @@
 
 .code-block-wrapper {
   position: relative;
+  contain: inline-size;
 }
 
 .md-content > .code-block-wrapper {


### PR DESCRIPTION
## Changes
- I had looked into this over the weekend but forgot to open a PR
- Several docs pages had layout issues on mobile because tables and code blocks had larger intrinsic sizes than their containers' widths.
- Fixed with contain, ignoring intrinsic size.
- Added horizontal scrolling where relevant.


https://github.com/user-attachments/assets/9ef70bb7-3782-4e09-a4d5-af1e331a8685


https://github.com/user-attachments/assets/1a9ac26a-93bb-4f40-b793-f46c6517ff30



## How to Review

By browsing around the docs site on either desktop or mobile.