### PR TITLE
css: skipBuild option

### DIFF
--- a/.changeset/rotten-pants-whisper.md
+++ b/.changeset/rotten-pants-whisper.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-css": patch
+---
+
+Add skipBuild option to skip generating .css files

--- a/packages/plugin-css/src/index.ts
+++ b/packages/plugin-css/src/index.ts
@@ -14,6 +14,7 @@ export default function cssPlugin({
   modeSelectors,
   transform: customTransform,
   utility,
+  skipBuild,
 }: CSSPluginOptions = {}): Plugin {
   const transformName = (id: string) => variableName?.(id) || makeCSSVar(id);
   const transformAlias = (id: string) => `var(${transformName(id)})`;
@@ -48,6 +49,10 @@ export default function cssPlugin({
       }
     },
     async build({ getTransforms, outputFile }) {
+      if (skipBuild === true) {
+        return;
+      }
+
       const output: string[] = [FILE_PREFIX, ''];
       output.push(
         buildFormat({ exclude, getTransforms, modeSelectors, utility }),

--- a/packages/plugin-css/src/lib.ts
+++ b/packages/plugin-css/src/lib.ts
@@ -23,6 +23,8 @@ export interface CSSPluginOptions {
   transform?: (token: TokenNormalized, mode: string) => TokenTransformed['value'];
   /** Generate utility CSS from groups */
   utility?: Record<UtilityCSSGroup, string[]>;
+  /** Skip generating any `.css` files (useful if you are consuming values in your own plugin and don’t need any `.css` files written to disk). */
+  skipBuild?: boolean;
 }
 
 export interface ModeSelector {

--- a/packages/plugin-css/test/cli.test.ts
+++ b/packages/plugin-css/test/cli.test.ts
@@ -71,5 +71,14 @@ describe('tz build', () => {
         fileURLToPath(new URL('./styles/out/want.css', cwd)),
       );
     });
+
+    it('skipBuild', async () => {
+      const cwd = new URL('./fixtures/cli-skip-build/', import.meta.url);
+      const before = fs.readdirSync(cwd);
+      await execa('node', [cmd, 'build'], { cwd });
+      const after = fs.readdirSync(cwd);
+      // assert absolutely no files or folders were created
+      expect(after.length, `${after.length - before.length} file/folder(s) generated`).toBe(before.length);
+    });
   });
 });

--- a/packages/plugin-css/test/fixtures/cli-skip-build/terrazzo.config.js
+++ b/packages/plugin-css/test/fixtures/cli-skip-build/terrazzo.config.js
@@ -2,11 +2,10 @@ import { defineConfig } from '@terrazzo/cli';
 import css from '../../../dist/index.js';
 
 export default defineConfig({
-  tokens: ['./styles/tokens.json'],
-  outDir: './styles/',
+  tokens: ['./tokens.json'],
   plugins: [
     css({
-      filename: 'out/actual.css',
+      skipBuild: true,
     }),
   ],
 });

--- a/packages/plugin-css/test/fixtures/cli-skip-build/tokens.json
+++ b/packages/plugin-css/test/fixtures/cli-skip-build/tokens.json
@@ -1,0 +1,10 @@
+{
+  "color": {
+    "$type": "color",
+    "base": {
+      "gray": {
+        "10": { "$value": { "colorSpace": "lab", "channels": [0.1, 0, 0], "alpha": 1 } }
+      }
+    }
+  }
+}

--- a/www/src/pages/docs/cli/integrations/css.md
+++ b/www/src/pages/docs/cli/integrations/css.md
@@ -311,6 +311,7 @@ export default defineConfig({
 | `variableName`  | `(id: string) => string`                                       | Function that takes in a token ID and returns a CSS variable name. Use this if you want to prefix your CSS variables, or rename them in any way. |
 | `transform`     | `(token: TokenNormalized) => string \| Record<string, string>` | Override certain token values by [transforming them](#transform)                                                                                 |
 | `utility`       | [Utility CSS mapping](#utility-css)                            | Generate Utility CSS from your tokens ([docs](#utility-css)                                                                                      |
+| `skipBuild`     | `boolean`                                                      | Skip generating any `.css` files (useful if you are consuming values in your own plugin and don’t need any `.css` files written to disk).        |
 
 ### Mode Selectors
 


### PR DESCRIPTION
## Changes

Fixes #410. Adds `skipBuild` option, for people using `plugin-css` only for its generated values, not the `.css` files themselves

## How to Review

- Test added