### PR TITLE
Enable CLI debugging

### DIFF
--- a/.changeset/pretty-sheep-tease.md
+++ b/.changeset/pretty-sheep-tease.md
@@ -1,0 +1,7 @@
+---
+"@terrazzo/cli": patch
+"@terrazzo/parser": patch
+"@terrazzo/token-tools": patch
+---
+
+Enable debugging in CLI

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -66,9 +66,15 @@ const { values: flags, positionals } = parseArgs({
 // likely to see multiple at once. We want to remove stacktraces just for the
 // CLI context. So we wrap this logger with our own formatter that simply prints
 // the raw message.
+let logLevel = undefined;
+if (flags.silent || flags.quiet) {
+  logLevel = 'error';
+} else if (process.env.DEBUG) {
+  logLevel = 'debug';
+}
 const logger = new Logger({
   // set correct level of debugging
-  level: flags.silent || flags.quiet ? 'error' : undefined,
+  level: logLevel,
   // add debug messages, if requested
   debugScope: process.env.DEBUG,
 });

--- a/www/src/pages/docs/cli/index.md
+++ b/www/src/pages/docs/cli/index.md
@@ -59,6 +59,26 @@ While it’s tempting to lean toward _“flexibility,”_ that term is often ind
 
 :::
 
+## API
+
+| Command                 | Description                                                                                      |
+| :---------------------- | :----------------------------------------------------------------------------------------------- |
+| `init`                  | Scaffold out a new project from an existing design system.                                       |
+| `build`                 | Build tokens [with your plugins](/docs/cli/integrations) and also run [linting](/docs/cli/lint). |
+| `lint`                  | Only run [token linting](/docs/cli/lint) (not build).                                            |
+| `check [file]`          | Validate a given tokens JSON meets the DTCG specification.                                       |
+| `--help`                | Display help message.                                                                            |
+| `--silent` \| `--quiet` | Suppress warnings and logs.                                                                      |
+
+### Debugging
+
+With any command, set the `DEBUG` env var to a scope:
+
+- `DEBUG=* tz build`: debug all scopes
+- `DEBUG=parser tz build`: debug @terrazzo/parser
+- `DEBUG=lint tz build`: debug linting
+- `DEBUG=plugin tz build`: debug plugins
+
 ## Next Steps
 
 - See all [config options](/docs/cli/config)


### PR DESCRIPTION
## Changes

Gets the `DEBUG` flag working (at least as a first pass)

## How to Review

- CI will throw if CLI is horribly-broken
