### PR TITLE
fix: add missing function param for tokenToCulori()

### DIFF
--- a/packages/use-color/index.js
+++ b/packages/use-color/index.js
@@ -65,7 +65,7 @@ export function parse(color) {
 
     // DTCG tokens: convert to Culori format
     if (color.colorSpace && Array.isArray(color.channels)) {
-      normalizedColor = tokenToCulori();
+      normalizedColor = tokenToCulori(color);
     }
     if (!normalizedColor.mode) {
       throw new Error(`Invalid Culori color: ${JSON.stringify(normalizedColor)}`);


### PR DESCRIPTION
## Changes

Fixes bug in token lab with `EditableColorToken` not rendering properly. `useColor(value);` eventually calls `tokenToCulori()` without passing the value to be converted

## How to Review

1. Run `pnpm run dev`
2. Go to `localhost:5173`
3. Expand any of the color menus: `color > pink`

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/d761423c-d7da-44d1-9060-055d3d57e075" />
