### PR TITLE
replace isTokenMatch with wcmatch for 5x speedup

### DIFF
--- a/.changeset/fine-ducks-worry.md
+++ b/.changeset/fine-ducks-worry.md
@@ -1,0 +1,12 @@
+---
+'@terrazzo/cli': minor
+'@terrazzo/parser': minor
+'@terrazzo/plugin-css': minor
+'@terrazzo/plugin-js': minor
+'@terrazzo/plugin-sass': minor
+'@terrazzo/plugin-tailwind': minor
+'@terrazzo/token-tools': minor
+---
+
+- potential 5x speedup for @terrazzo/plugin-css
+- removed isTokenMatch from @terrazzo/token-tools

--- a/packages/parser/src/lint/plugin-core/rules/a11y-min-font-size.ts
+++ b/packages/parser/src/lint/plugin-core/rules/a11y-min-font-size.ts
@@ -1,6 +1,6 @@
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
-import wcmatch from 'wildcard-match';
 
 export const A11Y_MIN_FONT_SIZE = 'a11y/min-font-size';
 

--- a/packages/parser/src/lint/plugin-core/rules/a11y-min-font-size.ts
+++ b/packages/parser/src/lint/plugin-core/rules/a11y-min-font-size.ts
@@ -1,6 +1,6 @@
-import { isTokenMatch } from '@terrazzo/token-tools';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
+import wcmatch from 'wildcard-match';
 
 export const A11Y_MIN_FONT_SIZE = 'a11y/min-font-size';
 
@@ -31,8 +31,10 @@ const rule: LintRule<typeof ERROR_TOO_SMALL, RuleA11yMinFontSizeOptions> = {
       throw new Error('Must specify at least one of minSizePx or minSizeRem');
     }
 
+    const shouldIgnore = options.ignore ? wcmatch(options.ignore) : null;
+
     for (const t of Object.values(tokens)) {
-      if (options.ignore && isTokenMatch(t.id, options.ignore)) {
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
 

--- a/packages/parser/src/lint/plugin-core/rules/colorspace.ts
+++ b/packages/parser/src/lint/plugin-core/rules/colorspace.ts
@@ -1,6 +1,7 @@
-import { type ColorValueNormalized, isTokenMatch } from '@terrazzo/token-tools';
+import { type ColorValueNormalized } from '@terrazzo/token-tools';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
+import wcmatch from 'wildcard-match';
 
 export const COLORSPACE = 'core/colorspace';
 
@@ -37,9 +38,11 @@ const rule: LintRule<
       return;
     }
 
+    const shouldIgnore = options.ignore ? wcmatch(options.ignore) : null;
+
     for (const t of Object.values(tokens)) {
       // skip ignored tokens
-      if (options?.ignore && isTokenMatch(t.id, options.ignore)) {
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
 

--- a/packages/parser/src/lint/plugin-core/rules/colorspace.ts
+++ b/packages/parser/src/lint/plugin-core/rules/colorspace.ts
@@ -1,7 +1,7 @@
-import { type ColorValueNormalized } from '@terrazzo/token-tools';
+import type { ColorValueNormalized } from '@terrazzo/token-tools';
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
-import wcmatch from 'wildcard-match';
 
 export const COLORSPACE = 'core/colorspace';
 

--- a/packages/parser/src/lint/plugin-core/rules/descriptions.ts
+++ b/packages/parser/src/lint/plugin-core/rules/descriptions.ts
@@ -1,6 +1,6 @@
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
-import wcmatch from 'wildcard-match';
 
 export const DESCRIPTIONS = 'core/descriptions';
 

--- a/packages/parser/src/lint/plugin-core/rules/descriptions.ts
+++ b/packages/parser/src/lint/plugin-core/rules/descriptions.ts
@@ -1,6 +1,6 @@
-import { isTokenMatch } from '@terrazzo/token-tools';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
+import wcmatch from 'wildcard-match';
 
 export const DESCRIPTIONS = 'core/descriptions';
 
@@ -23,8 +23,10 @@ const rule: LintRule<typeof ERROR_MISSING_DESCRIPTION, RuleDescriptionsOptions> 
   },
   defaultOptions: {},
   create({ tokens, options, report }) {
+    const shouldIgnore = options.ignore ? wcmatch(options.ignore) : null;
+
     for (const t of Object.values(tokens)) {
-      if (options.ignore && isTokenMatch(t.id, options.ignore)) {
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
       if (!t.$description) {

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -1,7 +1,7 @@
 import { isAlias } from '@terrazzo/token-tools';
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
-import wcmatch from 'wildcard-match';
 
 export const DUPLICATE_VALUES = 'core/duplicate-values';
 

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -1,6 +1,7 @@
-import { isAlias, isTokenMatch } from '@terrazzo/token-tools';
+import { isAlias } from '@terrazzo/token-tools';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
+import wcmatch from 'wildcard-match';
 
 export const DUPLICATE_VALUES = 'core/duplicate-values';
 
@@ -25,9 +26,11 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
   create({ report, tokens, options }) {
     const values: Record<string, Set<any>> = {};
 
+    const shouldIgnore = options.ignore ? wcmatch(options.ignore) : null;
+
     for (const t of Object.values(tokens)) {
       // skip ignored tokens
-      if (options.ignore && isTokenMatch(t.id, options.ignore)) {
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
 

--- a/packages/parser/src/lint/plugin-core/rules/max-gamut.ts
+++ b/packages/parser/src/lint/plugin-core/rules/max-gamut.ts
@@ -1,5 +1,6 @@
-import { type ColorValueNormalized, isTokenMatch, tokenToCulori } from '@terrazzo/token-tools';
+import { type ColorValueNormalized, tokenToCulori } from '@terrazzo/token-tools';
 import { type Color, clampChroma } from 'culori';
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
 
@@ -73,9 +74,11 @@ const rule: LintRule<
       throw new Error(`Unknown gamut "${options.gamut}". Options are "srgb", "p3", or "rec2020"`);
     }
 
+    const shouldIgnore = options.ignore ? wcmatch(options.ignore) : null;
+
     for (const t of Object.values(tokens)) {
       // skip ignored tokens
-      if (options.ignore && isTokenMatch(t.id, options.ignore)) {
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
 

--- a/packages/parser/src/lint/plugin-core/rules/required-children.ts
+++ b/packages/parser/src/lint/plugin-core/rules/required-children.ts
@@ -1,6 +1,6 @@
-import { isTokenMatch } from '@terrazzo/token-tools';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
+import wcmatch from 'wildcard-match';
 
 export const REQUIRED_CHILDREN = 'core/required-children';
 
@@ -56,11 +56,13 @@ const rule: LintRule<
         throw new Error(`Match ${matchI}: must declare either \`requiredTokens: […]\` or \`requiredGroups: […]\``);
       }
 
+      const matcher = wcmatch(match);
+
       const matchGroups: string[] = [];
       const matchTokens: string[] = [];
       let tokensMatched = false;
       for (const t of Object.values(tokens)) {
-        if (!isTokenMatch(t.id, match)) {
+        if (!matcher(t.id)) {
           continue;
         }
         tokensMatched = true;

--- a/packages/parser/src/lint/plugin-core/rules/required-children.ts
+++ b/packages/parser/src/lint/plugin-core/rules/required-children.ts
@@ -1,6 +1,6 @@
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
-import wcmatch from 'wildcard-match';
 
 export const REQUIRED_CHILDREN = 'core/required-children';
 

--- a/packages/parser/src/lint/plugin-core/rules/required-modes.ts
+++ b/packages/parser/src/lint/plugin-core/rules/required-modes.ts
@@ -1,4 +1,4 @@
-import { isTokenMatch } from '@terrazzo/token-tools';
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
 
@@ -41,9 +41,11 @@ const rule: LintRule<never, RuleRequiredModesOptions> = {
         throw new Error(`Match ${matchI}: must declare \`modes: […]\``);
       }
 
+      const matcher = wcmatch(match);
+
       let tokensMatched = false;
       for (const t of Object.values(tokens)) {
-        if (!isTokenMatch(t.id, match)) {
+        if (!matcher(t.id)) {
           continue;
         }
         tokensMatched = true;

--- a/packages/parser/src/lint/plugin-core/rules/required-typography-properties.ts
+++ b/packages/parser/src/lint/plugin-core/rules/required-typography-properties.ts
@@ -1,4 +1,4 @@
-import { isTokenMatch } from '@terrazzo/token-tools';
+import wcmatch from 'wildcard-match';
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
 
@@ -28,8 +28,10 @@ const rule: LintRule<never, RuleRequiredTypographyPropertiesOptions> = {
       throw new Error(`"properties" can’t be empty`);
     }
 
+    const shouldIgnore = options.ignore ? wcmatch(options.ignore) : null;
+
     for (const t of Object.values(tokens)) {
-      if (options.ignore && isTokenMatch(t.id, options.ignore)) {
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
 

--- a/packages/parser/src/parse/validate.ts
+++ b/packages/parser/src/parse/validate.ts
@@ -7,7 +7,8 @@ import {
   evaluate,
   print,
 } from '@humanwhocodes/momoa';
-import { type Token, type TokenNormalized, isAlias, isTokenMatch, splitID } from '@terrazzo/token-tools';
+import { type Token, type TokenNormalized, isAlias, splitID } from '@terrazzo/token-tools';
+import wcmatch from 'wildcard-match';
 import type Logger from '../logger.js';
 import type { ConfigInit } from '../types.js';
 import { getObjMembers, injectObjMembers } from './json.js';
@@ -858,7 +859,7 @@ export default function validateTokenNode(
   // point. However, if we are ignoring this token (or respecting
   // $deprecated, we can omit it from the output.
   const $deprecated = members.$deprecated && (evaluate(members.$deprecated) as string | boolean | undefined);
-  if ((config.ignore.deprecated && $deprecated) || (config.ignore.tokens && isTokenMatch(id, config.ignore.tokens))) {
+  if ((config.ignore.deprecated && $deprecated) || (config.ignore.tokens && wcmatch(config.ignore.tokens)(id))) {
     return;
   }
 

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -39,7 +39,8 @@
     "@terrazzo/cli": "^0.8.0"
   },
   "dependencies": {
-    "@terrazzo/token-tools": "workspace:^"
+    "@terrazzo/token-tools": "workspace:^",
+    "wildcard-match": "^5.1.4"
   },
   "devDependencies": {
     "@terrazzo/cli": "workspace:^",

--- a/packages/plugin-css/src/build/index.ts
+++ b/packages/plugin-css/src/build/index.ts
@@ -1,6 +1,7 @@
 import type { BuildHookOptions } from '@terrazzo/parser';
-import { isTokenMatch } from '@terrazzo/token-tools';
 import { generateShorthand } from '@terrazzo/token-tools/css';
+import wcmatch from 'wildcard-match';
+import type { DocumentNode } from 'graphql';
 import { type CSSPluginOptions, type CSSRule, FORMAT_ID, printRules } from '../lib.js';
 import generateUtilityCSS from './utility-css.js';
 
@@ -39,9 +40,11 @@ export default function buildFormat({
     const rec2020Rule: CSSRule = { selectors: [baseSelector], nestedQuery: REC2020_MQ, declarations: {} };
     rules.push(rootRule, p3Rule, rec2020Rule);
 
+    const shouldExclude = wcmatch(exclude ?? []);
+
     for (const token of rootTokens) {
       // handle exclude (if any)
-      if (isTokenMatch(token.token.id, exclude ?? [])) {
+      if (shouldExclude(token.token.id)) {
         continue;
       }
 

--- a/packages/plugin-css/src/build/index.ts
+++ b/packages/plugin-css/src/build/index.ts
@@ -1,7 +1,6 @@
 import type { BuildHookOptions } from '@terrazzo/parser';
 import { generateShorthand } from '@terrazzo/token-tools/css';
 import wcmatch from 'wildcard-match';
-import type { DocumentNode } from 'graphql';
 import { type CSSPluginOptions, type CSSRule, FORMAT_ID, printRules } from '../lib.js';
 import generateUtilityCSS from './utility-css.js';
 

--- a/packages/plugin-css/src/build/utility-css.ts
+++ b/packages/plugin-css/src/build/utility-css.ts
@@ -1,6 +1,7 @@
 import type { TokenTransformed } from '@terrazzo/parser';
-import { isTokenMatch, kebabCase } from '@terrazzo/token-tools';
+import { kebabCase } from '@terrazzo/token-tools';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
+import wcmatch from 'wildcard-match';
 import type { CSSRule, UtilityCSSGroup, UtilityCSSPrefix } from '../lib.js';
 
 // micro-optimization: precompile all RegExs (which can be known) because dynamic compilation is a waste of resources
@@ -34,7 +35,8 @@ export default function generateUtilityCSS(
   groupEntries.sort((a, b) => a[0].localeCompare(b[0]));
 
   for (const [group, selectors] of groupEntries) {
-    const matchingTokens = tokens.filter((token) => isTokenMatch(token.token.id, selectors));
+    const selectorMatcher = wcmatch(selectors);
+    const matchingTokens = tokens.filter((token) => selectorMatcher(token.token.id));
     if (!matchingTokens.length) {
       // biome-ignore lint/suspicious/noConsole: intentional user log
       console.warn(`[@terrazzo/plugin-css] utility group "${group}" matched 0 tokens: ${JSON.stringify(selectors)}`);

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -40,7 +40,8 @@
     "@terrazzo/plugin-css": "^0.8.0"
   },
   "dependencies": {
-    "@terrazzo/token-tools": "workspace:^"
+    "@terrazzo/token-tools": "workspace:^",
+    "wildcard-match": "^5.1.4"
   },
   "devDependencies": {
     "@terrazzo/cli": "workspace:^",

--- a/packages/plugin-sass/src/build.ts
+++ b/packages/plugin-sass/src/build.ts
@@ -1,7 +1,7 @@
 import type { BuildHookOptions } from '@terrazzo/parser';
 import { FORMAT_ID } from '@terrazzo/plugin-css';
-import { isTokenMatch } from '@terrazzo/token-tools';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
+import wcmatch from 'wildcard-match';
 import { FILE_HEADER, MIXIN_TOKEN, MIXIN_TYPOGRAPHY, type SassPluginOptions } from './lib.js';
 
 export interface BuildParams {
@@ -14,10 +14,12 @@ export default function build({ getTransforms, options }: BuildParams): string {
 
   const output: string[] = [FILE_HEADER, ''];
 
+  const shouldExclude = wcmatch(options?.exclude ?? []);
+
   // main values
   output.push('$__token-values: (');
   for (const token of tokens) {
-    if (isTokenMatch(token.token.id, options?.exclude ?? [])) {
+    if (shouldExclude(token.token.id)) {
       continue;
     }
     // typography tokens handled later

--- a/packages/token-tools/src/id.ts
+++ b/packages/token-tools/src/id.ts
@@ -7,9 +7,9 @@ export function isAlias(value: string): boolean {
   return ALIAS_RE.test(value);
 }
 
-/** 
+/**
  * Match token against globs
- * 
+ *
  * @deprecated Use `wildcard-match` directly instead. It is recommended to call
  *   `wcmatch(globPatterns)` once and reuse the created function for performance.
  */

--- a/packages/token-tools/src/id.ts
+++ b/packages/token-tools/src/id.ts
@@ -7,16 +7,6 @@ export function isAlias(value: string): boolean {
   return ALIAS_RE.test(value);
 }
 
-/**
- * Match token against globs
- *
- * @deprecated Use `wildcard-match` directly instead. It is recommended to call
- *   `wcmatch(globPatterns)` once and reuse the created function for performance.
- */
-export function isTokenMatch(tokenID: string, globPatterns: string[]): boolean {
-  return wcmatch(globPatterns)(tokenID);
-}
-
 /** Same as isTokenMatch but returns the matching pattern */
 export function getTokenMatch(tokenId: string, globPatterns: string[]): string | undefined {
   for (const pattern of globPatterns) {

--- a/packages/token-tools/src/id.ts
+++ b/packages/token-tools/src/id.ts
@@ -7,7 +7,12 @@ export function isAlias(value: string): boolean {
   return ALIAS_RE.test(value);
 }
 
-/** Match token against globs */
+/** 
+ * Match token against globs
+ * 
+ * @deprecated Use `wildcard-match` directly instead. It is recommended to call
+ *   `wcmatch(globPatterns)` once and reuse the created function for performance.
+ */
 export function isTokenMatch(tokenID: string, globPatterns: string[]): boolean {
   return wcmatch(globPatterns)(tokenID);
 }

--- a/packages/token-tools/test/id.test.ts
+++ b/packages/token-tools/test/id.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getTokenMatch, isAlias, isTokenMatch, makeAlias, parseAlias, splitID } from '../src/id.js';
+import { getTokenMatch, isAlias, makeAlias, parseAlias, splitID } from '../src/id.js';
 
 describe('isAlias', () => {
   it('returns true for valid ID', () => {
@@ -22,27 +22,6 @@ describe('makeAlias', () => {
 
   it('existing aliases are kept', () => {
     expect(makeAlias('{color.blue.60}')).toBe('{color.blue.60}');
-  });
-});
-
-describe('isTokenMatch', () => {
-  it('basic', () => {
-    expect(isTokenMatch('color.blue.60', ['color.*'])).toBe(true);
-    expect(isTokenMatch('color.blue.60', ['*.blue.*'])).toBe(true);
-    expect(isTokenMatch('color.blue.60', ['*.60'])).toBe(true);
-    expect(isTokenMatch('color.blue.60', ['*'])).toBe(true);
-    expect(isTokenMatch('color.blue.60', ['color'])).toBe(false);
-    expect(isTokenMatch('color.blue.60', ['color.blue'])).toBe(false);
-    expect(isTokenMatch('color.blue.60', ['color.blue.50'])).toBe(false);
-    expect(
-      isTokenMatch('color.alias-1', [
-        'color.alias-1',
-        'color.alias-2',
-        'color.alias-3',
-        'color.alias-4',
-        'color.alias-5',
-      ]),
-    ).toBe(true);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@terrazzo/token-tools':
         specifier: workspace:^
         version: link:../token-tools
+      wildcard-match:
+        specifier: ^5.1.4
+        version: 5.1.4
     devDependencies:
       '@terrazzo/cli':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@terrazzo/token-tools':
         specifier: workspace:^
         version: link:../token-tools
+      wildcard-match:
+        specifier: ^5.1.4
+        version: 5.1.4
     devDependencies:
       '@terrazzo/cli':
         specifier: workspace:^


### PR DESCRIPTION
## Changes

Hi Drew! This PR removes all uses of `isTokenMatch`, instead calling `wcmatch` outside of loops and then using the returned function inside loops. I found that this dropped Figma's token build times from 35s down to 7s.

I left `isTokenMatch` since it's exported from `@terrazzo/token-tools`, but marked it as `@deprecated`. Not sure if that's the right move here, but given that it can lead to a big perf hit if used too much, I think it could be removed in the future.

Let me know if you think the `wcmatch(patterns)` call should be wrapped in a helper in `token-tools`, I could see it handling null inputs and returning a dummy function so callers don't have to handle that themselves.

---

I was profiling `tz build` and the `transform` function from wildcard-match was dominating the profile. I think it was one of those hidden quadratic complexity things because calling `wcmatch(patterns)` does a bunch of work to build up an efficient regex, but that work was being done repeatedly on the same patterns when it could be done once. 

<img width="1496" alt="Screenshot 2025-06-23 at 12 23 06 PM" src="https://github.com/user-attachments/assets/b70f9665-494e-40c1-881f-a34f330c5d72" />

[CPU-20250621T224815.cpuprofile](https://github.com/user-attachments/files/20868903/CPU-20250621T224815.cpuprofile)

## How to Review

This is mostly a find and replace of the `isTokenMatch` function, so it should be easy to review. The `wcmatch` function is called in the highest scope possible where the matching patterns can be compiled once by wcmatch, and then reused within loops.
