### PR TITLE
Output token description as inline comment in CSS

### DIFF
--- a/packages/plugin-css/src/build/index.ts
+++ b/packages/plugin-css/src/build/index.ts
@@ -59,21 +59,21 @@ export default function buildFormat({
 
       // single-value token
       if (token.type === 'SINGLE_VALUE') {
-        rootRule.declarations[localID] = token.value;
+        rootRule.declarations[localID] = { value: token.value, description: token.token.$description };
       }
 
       // multi-value token (wide gamut color)
       else if (token.value.srgb && token.value.p3 && token.value.rec2020) {
-        rootRule.declarations[localID] = token.value.srgb!;
+        rootRule.declarations[localID] = { value: token.value.srgb!, description: token.token.$description };
         if (token.value.p3 !== token.value.srgb) {
-          p3Rule.declarations[localID] = token.value.p3!;
-          rec2020Rule.declarations[localID] = token.value.rec2020!;
+          p3Rule.declarations[localID] = { value: token.value.p3!, description: token.token.$description };
+          rec2020Rule.declarations[localID] =  { value: token.value.rec2020!, description: token.token.$description };
 
           // handle aliases within color gamut media queries
           for (const alias of aliasTokens) {
             if (alias.localID && typeof alias.value === 'string') {
-              p3Rule.declarations[alias.localID] ??= alias.value;
-              rec2020Rule.declarations[alias.localID] ??= alias.value;
+              p3Rule.declarations[alias.localID] ??= { value: alias.value, description: token.token.$description };
+              rec2020Rule.declarations[alias.localID] ??= { value: alias.value, description: token.token.$description };
             }
           }
         }
@@ -83,10 +83,10 @@ export default function buildFormat({
       else if (token.type === 'MULTI_VALUE') {
         const shorthand = generateShorthand({ $type: token.token.$type, localID });
         if (shorthand) {
-          rootRule.declarations[token.localID ?? token.token.id] = shorthand;
+          rootRule.declarations[token.localID ?? token.token.id] = { value: shorthand, description: token.token.$description };
         }
         for (const [name, value] of Object.entries(token.value)) {
-          rootRule.declarations[name === '.' ? localID : [localID, name].join('-')] = value;
+          rootRule.declarations[name === '.' ? localID : [localID, name].join('-')] = { value, description: token.token.$description };
         }
       }
     }
@@ -105,7 +105,7 @@ export default function buildFormat({
     const selectorRule: CSSRule = { selectors, declarations: {} };
     const selectorP3Rule: CSSRule = { selectors, nestedQuery: P3_MQ, declarations: {} };
     const selectorRec2020Rule: CSSRule = { selectors, nestedQuery: REC2020_MQ, declarations: {} };
-    const selectorAliasDeclarations: Record<string, string> = {};
+    const selectorAliasDeclarations: CSSRule['declarations'] = {};
     rules.push(selectorRule, selectorP3Rule, selectorRec2020Rule);
 
     for (const token of selectorTokens) {
@@ -117,21 +117,21 @@ export default function buildFormat({
 
       // single-value token
       if (token.type === 'SINGLE_VALUE') {
-        selectorRule.declarations[localID] = token.value;
+        selectorRule.declarations[localID] = { value: token.value, description: token.token.$description };
       }
 
       // multi-value token (wide gamut color)
       else if (token.value.srgb && token.value.p3 && token.value.rec2020) {
-        selectorRule.declarations[localID] = token.value.srgb!;
+        selectorRule.declarations[localID] = { value: token.value.srgb!, description: token.token.$description };
         if (token.value.p3 !== token.value.srgb) {
-          selectorP3Rule.declarations[localID] = token.value.p3!;
-          selectorRec2020Rule.declarations[localID] = token.value.rec2020!;
+          selectorP3Rule.declarations[localID] = { value: token.value.p3!, description: token.token.$description };
+          selectorRec2020Rule.declarations[localID] = { value: token.value.rec2020!, description: token.token.$description };
 
           // handle aliases within color gamut media queries
           for (const alias of aliasTokens) {
             if (alias.localID && typeof alias.value === 'string') {
-              selectorP3Rule.declarations[alias.localID] ??= alias.value;
-              selectorRec2020Rule.declarations[alias.localID] ??= alias.value;
+              selectorP3Rule.declarations[alias.localID] ??= { value: alias.value, description: token.token.$description };
+              selectorRec2020Rule.declarations[alias.localID] ??= { value: alias.value, description: token.token.$description };
             }
           }
         }
@@ -141,24 +141,24 @@ export default function buildFormat({
       else {
         const shorthand = generateShorthand({ $type: token.token.$type, localID });
         if (shorthand) {
-          selectorRule.declarations[localID] = shorthand;
+          selectorRule.declarations[localID] = { value: shorthand, description: token.token.$description };
         }
         for (const [name, subvalue] of Object.entries(token.value)) {
-          selectorRule.declarations[`${localID}-${name}`] = subvalue;
+          selectorRule.declarations[`${localID}-${name}`] = { value: subvalue, description: token.token.$description };
         }
       }
 
       // redeclare aliases so they have the correct scope
       for (const alias of aliasTokens) {
         if (alias.localID && typeof alias.value === 'string') {
-          selectorAliasDeclarations[alias.localID] = alias.value;
+          selectorAliasDeclarations[alias.localID] = { value: alias.value, description: token.token.$description };
         }
       }
     }
 
     // after selector has settled, add in aliases if there are no conflicts
-    for (const [name, value] of Object.entries(selectorAliasDeclarations)) {
-      selectorRule.declarations[name] ??= value;
+    for (const [name, {value, description}] of Object.entries(selectorAliasDeclarations)) {
+      selectorRule.declarations[name] ??= { value, description };
     }
   }
 

--- a/packages/plugin-css/src/lib.ts
+++ b/packages/plugin-css/src/lib.ts
@@ -55,10 +55,14 @@ export interface ModeSelector {
 // A CSSRule is a sort of “we have AST at home” shortcut that provides the benefit of normalized formatting
 // but without the overhead/complexity of a full AST. It’s useful because we only generate a limited CSS
 // syntax, and is a good balance between spec-compliance vs ease-of-use.
+interface CSSRuleDeclaration {
+  value: string;
+  description?: string;
+}
 export interface CSSRule {
   selectors: string[];
   nestedQuery?: string;
-  declarations: Record<string, string>;
+  declarations: Record<string, CSSRuleDeclaration>;
 }
 
 /** Convert CSSRules into a formatted, indented CSS string */
@@ -117,8 +121,8 @@ function _printRule(rule: CSSRule): string {
 
   const declarations = Object.entries(rule.declarations);
   declarations.sort((a, b) => a[0].localeCompare(b[0], 'en-us', { numeric: true }));
-  for (const [k, v] of declarations) {
-    output.push(`${indent}${k}: ${v};`);
+  for (const [k, d] of declarations) {
+    output.push(`${indent}${k}: ${d.value};${d.description ? ` /* ${d.description} */` : ''}`);
   }
 
   // base closing brackets on indent level


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

Fixes https://github.com/terrazzoapp/terrazzo/issues/512

- Add a `description` field to the CSS Rule declarations
- Grab the token's `$description` (if any) and save it in the new `description` field
- When writing to file, add an inline CSS comment with the description (if any)

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_
