### PR TITLE
fix: Rework rolldown -w scripts to avoid arg parsing error on bash shell

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack . && vite build",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/cli run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/plugin-css run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/plugin-js/package.json
+++ b/packages/plugin-js/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/plugin-js run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/plugin-sass run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/plugin-swift/package.json
+++ b/packages/plugin-swift/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "biome check .",
     "test": "vitest run"

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/plugin-tailwind run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/plugin-vanilla-extract/package.json
+++ b/packages/plugin-vanilla-extract/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/plugin-vanilla-extract run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/token-tools/package.json
+++ b/packages/token-tools/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -c -w",
+    "dev": "rolldown -w -c",
     "lint": "pnpm --filter @terrazzo/token-tools run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",
     "lint:ts": "tsc --noEmit",


### PR DESCRIPTION
## Changes

Reworks `dev` commands so that `-c -w` isn't interpreted as longer a config file at `./\-w`.

## How to Review

1. Install Linux :penguin:
2. On Linux, run `pnpm dev` in a package with that script
