### PR TITLE
feat: Support deprecated inheritence

### DIFF
--- a/.changeset/tiny-facts-stay.md
+++ b/.changeset/tiny-facts-stay.md
@@ -1,5 +1,5 @@
 ---
-"@terrazzo/parser": minor
+"@terrazzo/parser": patch
 ---
 
 Support the $deprecated prop being inherited from a token's group

--- a/.changeset/tiny-facts-stay.md
+++ b/.changeset/tiny-facts-stay.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/parser": minor
+---
+
+Support the $deprecated prop being inherited from a token's group

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "pnpm run build --watch",
+    "dev": "rolldown -w -c",
     "lint": "pnpm --filter @terrazzo/parser run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",
     "lint:ts": "tsc --noEmit",

--- a/packages/parser/test/parse.test.ts
+++ b/packages/parser/test/parse.test.ts
@@ -2797,6 +2797,55 @@ describe('Additional cases', () => {
     });
   });
 
+  describe('$deprecated', () => {
+    it('property is not forwarded when aliasing', async () => {
+      const config = defineConfig({}, { cwd });
+      const result = await parse(
+        [
+          {
+            filename: DEFAULT_FILENAME,
+            src: {
+              color: {
+                base: { blue: { 500: { $type: 'color', $deprecated: true, $value: 'color(srgb 0 0.2 1)' } } },
+                semantic: { $value: '{color.base.blue.500}' },
+              },
+            },
+          },
+        ],
+        { config },
+      );
+      expect(result.tokens['color.base.blue.500']?.$deprecated).toBe(true);
+      expect(result.tokens['color.semantic']?.$deprecated).toBe(undefined);
+    });
+
+    it('inheritance works', async () => {
+      const config = defineConfig({}, { cwd });
+      const result = await parse(
+        [
+          {
+            filename: DEFAULT_FILENAME,
+            src: {
+              color: {
+                $type: 'color',
+                combava: {
+                  400: { $value: '#66945b' },
+                },
+                lime: {
+                  $deprecated: 'Use combava instead',
+                  200: { $deprecated: false, $value: '#f3ffe0ff' },
+                  400: { $value: '#dfffad' },
+                },
+              },
+            },
+          },
+        ],
+        { config },
+      );
+      expect(result.tokens['color.lime.200']?.$deprecated).toBe(false);
+      expect(result.tokens['color.lime.400']?.$deprecated).toBe('Use combava instead');
+    });
+  });
+
   describe('values', () => {
     const tests: [string, { given: any; want: any }][] = [
       [


### PR DESCRIPTION
## Changes

* Ensures the `$deprecated` property gets inherited from groups, just like `$type`
* nit: Refactors parser code to avoid a few redundant code paths around inherited props

## How to Review

* Run unit tests
* Checkout `feat/token-listing` which has this branch applied, build, `cd packages/debug && p terrazzo build`, open resulting listing file and see deprecated tokens at the end of the file , which match `$deprecated` attrs placed in `tokens.json`
