### PR TITLE
fix(plugin-tailwind): resolve template path relative to outDir in readFile

### DIFF
--- a/.changeset/plugin-tailwind-template-path-resolution.md
+++ b/.changeset/plugin-tailwind-template-path-resolution.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-tailwind": patch
+---
+
+fix(plugin-tailwind): resolve template path relative to outDir in readFile

--- a/packages/plugin-tailwind/src/index.ts
+++ b/packages/plugin-tailwind/src/index.ts
@@ -50,7 +50,7 @@ export default function pluginTailwind(options: TailwindPluginOptions): Plugin {
     },
     async transform({ getTransforms, setTransform, context: { logger } }) {
       // First, validate template, and parse the locations of all @tz at-rules.
-      template = await fs.readFile(options.template, 'utf8');
+      template = await fs.readFile(new URL(options.template, cwd), 'utf8');
       if (!template.includes('@tz')) {
         logger.error({
           ...msg,


### PR DESCRIPTION
## Summary

The `config` hook resolves the template path relative to `outDir` via `new URL(options.template, cwd)` for the `existsSync` check, but the `transform` hook passes `options.template` directly to `fs.readFile`, which resolves it relative to `process.cwd()`.

In monorepo/workspace setups where the working directory differs from the package directory (e.g. `npm run tokens -w packages/tokens`), this causes `readFile` to fail with `ENOENT` even though the `existsSync` check passes.

## Reproduction

1. Set up an npm workspace monorepo with tokens in a sub-package:
   ```
   my-monorepo/
     package.json          # { "workspaces": ["packages/*"] }
     packages/
       tokens/
         terrazzo.config.ts
         tailwind.template.css
         generated/          # outDir
   ```

2. In `terrazzo.config.ts`:
   ```ts
   tailwind({
     template: "../tailwind.template.css",  // relative to outDir (generated/)
     // ...
   })
   ```

3. Run from monorepo root: `npm run tokens -w packages/tokens`

4. `existsSync` resolves correctly (relative to `outDir`), but `readFile` fails because it resolves relative to `process.cwd()` (monorepo root).

## Fix

Use the same `new URL(options.template, cwd)` resolution for `fs.readFile` as is already used for `fsSync.existsSync`.

```diff
- template = await fs.readFile(options.template, 'utf8');
+ template = await fs.readFile(new URL(options.template, cwd), 'utf8');
```