### PR TITLE
fix: add build queue to watch/dev mode

### DIFF
--- a/.changeset/brave-watch-queue.md
+++ b/.changeset/brave-watch-queue.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/cli": patch
+---
+
+fix: add build queue to watch/dev mode to prevent overlapping builds

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -54,6 +54,14 @@ export async function buildCmd({ config, configPath, flags, logger }: BuildOptio
         minute: '2-digit',
       });
 
+      let building = false;
+      let pending:
+        | {
+            messageBefore?: string;
+            messageAfter?: string;
+          }
+        | undefined;
+
       async function rebuild({ messageBefore, messageAfter }: { messageBefore?: string; messageAfter?: string } = {}) {
         try {
           if (messageBefore) {
@@ -77,19 +85,37 @@ export async function buildCmd({ config, configPath, flags, logger }: BuildOptio
         } catch (err) {
           // biome-ignore lint/suspicious/noConsole: this is its job
           console.error(pc.red(`✗  ${(err as Error).message || (err as string)}`));
-          // don’t exit! we’re watching, so continue as long as possible
+          // don't exit! we're watching, so continue as long as possible
+        }
+      }
+
+      async function queueRebuild(options: { messageBefore?: string; messageAfter?: string } = {}) {
+        if (building) {
+          pending = options;
+          return;
+        }
+        building = true;
+        try {
+          await rebuild(options);
+        } finally {
+          building = false;
+          if (pending) {
+            const next = pending;
+            pending = undefined;
+            await queueRebuild(next);
+          }
         }
       }
 
       const tokenWatcher = chokidar.watch(config.tokens.map((filename) => fileURLToPath(filename)));
       tokenWatcher.on('change', async (filename) => {
-        await rebuild({
-          messageBefore: `${pc.dim(dt.format(new Date()))} ${pc.green('tz')}} ${pc.yellow(filename)} updated ${GREEN_CHECK}`,
+        await queueRebuild({
+          messageBefore: `${pc.dim(dt.format(new Date()))} ${pc.green('tz')} ${pc.yellow(filename)} updated ${GREEN_CHECK}`,
         });
       });
       const configWatcher = chokidar.watch(resolveConfig(configPath)!);
       configWatcher.on('change', async () => {
-        await rebuild({
+        await queueRebuild({
           messageBefore: `${pc.dim(dt.format(new Date()))} ${pc.green('tz')} ${pc.yellow('Config updated. Reloading…')}`,
         });
       });


### PR DESCRIPTION
Fixes #541

## Summary
Watch mode previously had no build queuing — rapid file changes could trigger overlapping builds or drop events. Added a lock/debounce mechanism:

- **Lock**: Concurrent builds are prevented via a `building` boolean
- **Debounce**: While a build is in progress, only the most recent change event is retained in `pending`; all earlier events are discarded
- **Drain**: When a build completes, if a pending event exists, it's processed recursively

This matches the maintainer's spec: hold incoming requests while a build is in progress, discard all but the most recent, execute the latest when the current build finishes.

## Test plan
- [x] 18/18 CLI tests pass
- [x] Rapid file changes no longer cause overlapping plugin calls
- [x] No regressions in existing watch behavior