### PR TITLE
fix: normalize token IDs regardless of alphabetize setting

### DIFF
--- a/packages/parser/src/parse/process.ts
+++ b/packages/parser/src/parse/process.ts
@@ -253,24 +253,24 @@ export function processTokens(
   }
   logger.debug({ ...entry, message: 'Normalized values', timing: performance.now() - normalizeStart });
 
-  // 6. alphabetize & filter
+  // 6. normalize IDs & optionally alphabetize
   // This can’t happen until the last step, where we’re 100% sure we’ve resolved everything.
-  if (config.alphabetize === false) {
-    return tokens;
-  }
-
   const sortStart = performance.now();
-  const tokensSorted: TokenNormalizedSet = {};
-  tokenIDs.sort(alphaComparator);
+  if (config.alphabetize !== false) {
+    tokenIDs.sort(alphaComparator);
+  }
+  const tokensNormalized: TokenNormalizedSet = {};
   for (const path of tokenIDs) {
     const id = refToTokenID(path)!;
-    tokensSorted[id] = tokens[path]!;
+    tokensNormalized[id] = tokens[path]!;
   }
-  // Sort group IDs once, too
-  for (const group of Object.values(groups)) {
-    group.tokens.sort(alphaComparator);
+  if (config.alphabetize !== false) {
+    // Sort group IDs once, too
+    for (const group of Object.values(groups)) {
+      group.tokens.sort(alphaComparator);
+    }
   }
   logger.debug({ ...entry, message: 'Sorted tokens', timing: performance.now() - sortStart });
 
-  return tokensSorted;
+  return tokensNormalized;
 }

--- a/packages/parser/test/parse.test.ts
+++ b/packages/parser/test/parse.test.ts
@@ -76,6 +76,60 @@ describe('Additional cases', () => {
     }
   });
 
+  describe('alphabetize', () => {
+    it('token IDs use dot notation when alphabetize is false', async () => {
+      const config = defineConfig({ alphabetize: false }, { cwd });
+      const result = await parse(
+        [
+          {
+            filename: DEFAULT_FILENAME,
+            src: {
+              size: {
+                $type: 'dimension',
+                sm: { $value: { value: 4, unit: 'px' } },
+                md: { $value: { value: 8, unit: 'px' } },
+                base: { $value: '{size.sm}' },
+              },
+            },
+          },
+        ],
+        { config },
+      );
+      // Token IDs should use dot notation regardless of alphabetize setting
+      expect(result.tokens['size.sm']).toBeDefined();
+      expect(result.tokens['size.md']).toBeDefined();
+      expect(result.tokens['size.base']).toBeDefined();
+      // Should NOT have JSON Pointer format keys
+      expect(result.tokens['#/size/sm']).toBeUndefined();
+      expect(result.tokens['#/size/md']).toBeUndefined();
+      expect(result.tokens['#/size/base']).toBeUndefined();
+    });
+
+    it('token IDs use dot notation when alphabetize is true', async () => {
+      const config = defineConfig({ alphabetize: true }, { cwd });
+      const result = await parse(
+        [
+          {
+            filename: DEFAULT_FILENAME,
+            src: {
+              size: {
+                $type: 'dimension',
+                sm: { $value: { value: 4, unit: 'px' } },
+                md: { $value: { value: 8, unit: 'px' } },
+              },
+            },
+          },
+        ],
+        { config },
+      );
+      expect(result.tokens['size.sm']).toBeDefined();
+      expect(result.tokens['size.md']).toBeDefined();
+      // Should also be sorted
+      const ids = Object.keys(result.tokens);
+      expect(ids).toEqual([...ids].sort());
+    });
+  });
+
   describe('$type', () => {
     it('aliases get updated', async () => {
       const config = defineConfig({}, { cwd });


### PR DESCRIPTION
## Summary

Fixes #734

When `alphabetize` is set to `false`, the early return in `process.ts` (line 258) skipped the `refToTokenID()` conversion, causing token IDs to remain in JSON Pointer format (`#/size/sm`) instead of dot notation (`size.sm`).

This change ensures `refToTokenID()` always runs on token IDs while only conditionally sorting them, so token ID format is consistent regardless of the `alphabetize` setting.

## Changes

- Removed the early return when `alphabetize === false`
- Always apply `refToTokenID()` conversion to normalize token IDs
- Conditionally sort with `alphaComparator` only when `alphabetize !== false`
- Conditionally sort group token arrays only when `alphabetize !== false`

## Test plan

- All 258 existing tests pass
- Verified build succeeds