### PR TITLE
feat: add OAuth bearer token support for Figma import

### DIFF
--- a/.changeset/figma-oauth-support.md
+++ b/.changeset/figma-oauth-support.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/cli": minor
+---
+
+Add OAuth bearer token support for Figma import. Set `FIGMA_OAUTH_TOKEN` to use an OAuth access token instead of a Personal Access Token (`FIGMA_ACCESS_TOKEN`). OAuth takes precedence if both are set.

--- a/packages/cli/src/import/figma/lib.ts
+++ b/packages/cli/src/import/figma/lib.ts
@@ -36,11 +36,30 @@ export function getFileID(url: string) {
   return url.match(/^https:\/\/(www\.)?figma\.com\/design\/([^/]+)/)?.[2];
 }
 
+/**
+ * Returns Figma API auth headers based on environment variables.
+ * Prefers OAuth (FIGMA_OAUTH_TOKEN) over PAT (FIGMA_ACCESS_TOKEN) if both are set.
+ * Warns via logger and returns empty headers if neither is set.
+ */
+export function getFigmaAuthHeaders(logger: Logger): Record<string, string> {
+  if (process.env.FIGMA_OAUTH_TOKEN) {
+    return { Authorization: `Bearer ${process.env.FIGMA_OAUTH_TOKEN}` };
+  }
+
+  if (process.env.FIGMA_ACCESS_TOKEN) {
+    return { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN };
+  }
+
+  logger.warn({ group: 'config', message: 'Figma auth not configured! Set FIGMA_OAUTH_TOKEN or FIGMA_ACCESS_TOKEN' });
+
+  return {};
+}
+
 /** /v1/files/:file_key */
 export async function getFile(fileKey: string, { logger }: { logger: Logger }) {
   const res = await fetch(API.file.replace(FILE_KEY, fileKey), {
     method: 'GET',
-    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    headers: getFigmaAuthHeaders(logger),
   });
   if (!res.ok) {
     logger.error({ group: 'import', message: `${res.status} ${await res.text()}` });
@@ -56,7 +75,7 @@ export async function getFileNodes(fileKey: string, { ids, logger }: { logger: L
   }
   const res = await fetch(url, {
     method: 'GET',
-    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    headers: getFigmaAuthHeaders(logger),
   });
   if (!res.ok) {
     logger.error({ group: 'import', message: `${res.status} ${await res.text()}` });
@@ -68,7 +87,7 @@ export async function getFileNodes(fileKey: string, { ids, logger }: { logger: L
 export async function getFileStyles(fileKey: string, { logger }: { logger: Logger }) {
   const res = await fetch(API.fileStyles.replace(FILE_KEY, fileKey), {
     method: 'GET',
-    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    headers: getFigmaAuthHeaders(logger),
   });
   if (!res.ok) {
     logger.error({ group: 'import', message: `${res.status} ${await res.text()}` });
@@ -80,7 +99,7 @@ export async function getFileStyles(fileKey: string, { logger }: { logger: Logge
 export async function getFileLocalVariables(fileKey: string, { logger }: { logger: Logger }) {
   const res = await fetch(API.localVariables.replace(FILE_KEY, fileKey), {
     method: 'GET',
-    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    headers: getFigmaAuthHeaders(logger),
   });
   if (!res.ok) {
     logger.error({ group: 'import', message: `${res.status} ${await res.text}` });
@@ -92,7 +111,7 @@ export async function getFileLocalVariables(fileKey: string, { logger }: { logge
 export async function getFilePublishedVariables(fileKey: string, { logger }: { logger: Logger }) {
   const res = await fetch(API.publishedVariables.replace(FILE_KEY, fileKey), {
     method: 'GET',
-    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    headers: getFigmaAuthHeaders(logger),
   });
   if (!res.ok) {
     logger.error({ group: 'import', message: `${res.status} ${await res.text}` });

--- a/packages/cli/src/import/index.ts
+++ b/packages/cli/src/import/index.ts
@@ -26,11 +26,11 @@ export async function importCmd({ flags, positionals, logger }: ImportCmdOptions
   }
 
   if (isFigmaPath(url!)) {
-    const { FIGMA_ACCESS_TOKEN } = process.env;
-    if (!FIGMA_ACCESS_TOKEN) {
+    const { FIGMA_ACCESS_TOKEN, FIGMA_OAUTH_TOKEN } = process.env;
+    if (!FIGMA_ACCESS_TOKEN && !FIGMA_OAUTH_TOKEN) {
       logger.error({
         group: 'import',
-        message: `FIGMA_ACCESS_TOKEN not set! See https://terrazzo.app/docs/guides/import-from-figma`,
+        message: `Figma auth not configured! Set FIGMA_OAUTH_TOKEN (OAuth access token) or FIGMA_ACCESS_TOKEN (Personal Access Token). See https://terrazzo.app/docs/guides/import-from-figma`,
       });
     }
 

--- a/packages/cli/src/shared.ts
+++ b/packages/cli/src/shared.ts
@@ -6,6 +6,7 @@ import pc from 'picocolors';
 import { createServer, type ViteDevServer } from 'vite';
 import { ViteNodeRunner } from 'vite-node/client';
 import { ViteNodeServer } from 'vite-node/server';
+import { getFigmaAuthHeaders } from './import/figma/lib.js';
 
 export const cwd = new URL(`${pathToFileURL(process.cwd())}/`); // trailing slash needed to interpret as directory
 export const DEFAULT_CONFIG_PATH = new URL('./terrazzo.config.ts', cwd);
@@ -167,12 +168,8 @@ export async function loadTokens(tokenPaths: URL[], { logger }: { logger: Logger
             const headers = new Headers({
               Accept: '*/*',
               'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0',
+              ...getFigmaAuthHeaders(logger),
             });
-            if (process.env.FIGMA_ACCESS_TOKEN) {
-              headers.set('X-FIGMA-TOKEN', process.env.FIGMA_ACCESS_TOKEN);
-            } else {
-              logger.warn({ group: 'config', message: 'FIGMA_ACCESS_TOKEN not set' });
-            }
             const res = await fetch(`https://api.figma.com/v1/files/${fileKey}/variables/local`, {
               method: 'GET',
               headers,

--- a/packages/cli/test/import.test.ts
+++ b/packages/cli/test/import.test.ts
@@ -1,12 +1,8 @@
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { Logger } from '@terrazzo/parser';
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { importCmd } from '../src/index.js';
-
-vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
-
-const originalFetch = globalThis.fetch;
 
 describe('import', () => {
   describe('figma', async () => {
@@ -19,7 +15,10 @@ describe('import', () => {
     const FIGMA_GET_STYLES = await fs.readFile(new URL('get-styles.json', cwd), 'utf8');
 
     beforeEach(() => {
-      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+      vi.stubEnv('FIGMA_OAUTH_TOKEN', '');
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
         return Promise.resolve(
           new Response(
             {
@@ -27,14 +26,15 @@ describe('import', () => {
               [`https://api.figma.com/v1/files/${FILE_KEY}/styles`]: FIGMA_GET_STYLES,
               [`https://api.figma.com/v1/files/${FILE_KEY}/variables/local`]: FIGMA_GET_LOCAL_VARIABLES,
               [`https://api.figma.com/v1/files/${FILE_KEY}/variables/published`]: FIGMA_GET_PUBLISHED_VARIABLES,
-            }[url.replace(/\?.*$/, '')],
+            }[url.toString().replace(/\?.*$/, '')],
           ),
         );
       });
     });
 
-    afterAll(() => {
-      globalThis.fetch = originalFetch;
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
     });
 
     it('default', async () => {
@@ -100,6 +100,41 @@ describe('import', () => {
       await expect(await fs.readFile(new URL('import-name-matchers.actual.json', cwd), 'utf8')).toMatchFileSnapshot(
         fileURLToPath(new URL('import-name-matchers.want.json', cwd)),
       );
+    });
+
+    describe('auth headers', () => {
+      const positionals = ['import', `https://www.figma.com/design/${FILE_KEY}/My-File?node-id=1:1`];
+      const flags = { output: 'test/fixtures/import-figma/import-default.actual.json' };
+
+      it('PAT: sends X-Figma-Token', async () => {
+        vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+        vi.stubEnv('FIGMA_OAUTH_TOKEN', '');
+        await importCmd({ logger: new Logger(), positionals, flags });
+        expect(globalThis.fetch).toHaveBeenCalledWith(expect.any(String), {
+          method: 'GET',
+          headers: { 'X-Figma-Token': 'fig_fake_token' },
+        });
+      });
+
+      it('OAuth: sends Authorization: Bearer', async () => {
+        vi.stubEnv('FIGMA_ACCESS_TOKEN', '');
+        vi.stubEnv('FIGMA_OAUTH_TOKEN', 'fig_fake_oauth_token');
+        await importCmd({ logger: new Logger(), positionals, flags });
+        expect(globalThis.fetch).toHaveBeenCalledWith(expect.any(String), {
+          method: 'GET',
+          headers: { Authorization: 'Bearer fig_fake_oauth_token' },
+        });
+      });
+
+      it('precedence: OAuth wins when both tokens are set', async () => {
+        vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_pat_token');
+        vi.stubEnv('FIGMA_OAUTH_TOKEN', 'fig_oauth_token');
+        await importCmd({ logger: new Logger(), positionals, flags });
+        expect(globalThis.fetch).toHaveBeenCalledWith(expect.any(String), {
+          method: 'GET',
+          headers: { Authorization: 'Bearer fig_oauth_token' },
+        });
+      });
     });
   });
 });

--- a/www/src/pages/docs/guides/import-from-figma.md
+++ b/www/src/pages/docs/guides/import-from-figma.md
@@ -11,14 +11,14 @@ Figma Variables and Styles translate well to DTCG tokens! This guide will show y
 
 To import from Figma, you’ll need:
 
-1. A [personal access token](https://developers.figma.com/docs/rest-api/authentication/#access-tokens) with access to the file(s) you want to load Variables & Styles from
+1. A [personal access token](https://developers.figma.com/docs/rest-api/authentication/#access-tokens) or [OAuth token](https://developers.figma.com/docs/rest-api/authentication/#oauth-apps) with access to the file(s) you want to load Variables & Styles from
    - For **Styles**, it needs 3 [scopes](https://developers.figma.com/docs/rest-api/scopes/): `file_content:read`, `team_library_content:read`, and `library_content:read`.
    - For **Variables**, it needs 1 [scope](https://developers.figma.com/docs/rest-api/scopes/): `file_variables:read`.
 2. An Enterprise plan to access Variables (with free accounts, only Styles are importable)
 
-### Personal Access Token
+### Access Tokens
 
-Create your [personal access token](https://developers.figma.com/docs/rest-api/authentication/#access-tokens) from Settings inside Figma, and expose it as a `FIGMA_ACCESS_TOKEN` environment variable. You can do this in multiple ways:
+Expose your token as an environment variable: either `FIGMA_ACCESS_TOKEN` for a [personal access token](https://developers.figma.com/docs/rest-api/authentication/#access-tokens), or `FIGMA_OAUTH_TOKEN` for an [OAuth access token](https://developers.figma.com/docs/rest-api/authentication/#oauth-apps). If both are set, `FIGMA_OAUTH_TOKEN` takes precedence. You can set the variable in multiple ways:
 
 - Locally: run `echo 'export FIGMA_ACCESS_TOKEN="(your token value)"' >> ~/.zshrc` (this is great for testing!)
 - [GitHub Actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets): add to secrets


### PR DESCRIPTION
## Changes

Introduces OAuth support for Figma via the `FIGMA_OAUTH_TOKEN`

## How to Review

- fixes #739
