### PR TITLE
Ensure skipLint config is passed through to build command

### DIFF
--- a/.changeset/lazy-frogs-dream.md
+++ b/.changeset/lazy-frogs-dream.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/cli": patch
+---
+
+Respect --no-lint options in build command

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -65,6 +65,7 @@ const { values: flags, positionals } = parseArgs({
     watch: { type: 'boolean', short: 'w' },
     version: { type: 'boolean' },
     unpublished: { type: 'boolean' },
+    'no-lint': { type: 'boolean' },
     'skip-styles': { type: 'boolean' },
     'skip-variables': { type: 'boolean' },
     'font-family-names': { type: 'string' },

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -43,7 +43,8 @@ export async function buildCmd({ config, configPath, flags, logger }: BuildOptio
       });
       return;
     }
-    let { tokens, resolver, sources } = await parse(rawSchemas, { config, logger, yamlToMomoa });
+    const skipLint = !config.lint.build.enabled;
+    let { tokens, resolver, sources } = await parse(rawSchemas, { config, logger, skipLint, yamlToMomoa });
     let result = await build(tokens, { resolver, sources, config, logger });
     writeFiles(result, { config, logger });
 
@@ -65,7 +66,7 @@ export async function buildCmd({ config, configPath, flags, logger }: BuildOptio
               `Error loading ${path.relative(fileURLToPath(cwd), fileURLToPath(config.tokens[0] || DEFAULT_TOKENS_PATH))}`,
             );
           }
-          const parseResult = await parse(rawSchemas, { config, logger, yamlToMomoa });
+          const parseResult = await parse(rawSchemas, { config, logger, skipLint, yamlToMomoa });
           tokens = parseResult.tokens;
           sources = parseResult.sources;
           resolver = parseResult.resolver;

--- a/packages/cli/src/shared.ts
+++ b/packages/cli/src/shared.ts
@@ -22,6 +22,8 @@ export interface Flags {
   out?: string;
   /** --help */
   help?: boolean;
+  /** --no-lint */
+  'no-lint'?: boolean;
   /** --watch, -w */
   watch?: boolean;
   /** --version */
@@ -93,6 +95,9 @@ export async function loadConfig({ cmd, flags, logger }: LoadConfigOptions) {
           );
         }
         config = defineConfig(mod.default, { cwd, logger });
+        if (flags['no-lint']) {
+          config.lint.build.enabled = false;
+        }
       } catch (err) {
         logger.error({ group: 'config', message: (err as Error).message || (err as string) });
       }


### PR DESCRIPTION
## Changes

- [x] ensures `config.lint.build.enabled` is respected
- [x] respect `--skip-lint` flag.

## How to Review

- fixes #741