### PR TITLE
fix(plugin-css-in-js): camelCase intermediate path segments

### DIFF
--- a/.changeset/sour-stamps-start.md
+++ b/.changeset/sour-stamps-start.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-css-in-js": patch
+---
+
+fix: allow for dashes in token paths

--- a/packages/plugin-css-in-js/src/index.ts
+++ b/packages/plugin-css-in-js/src/index.ts
@@ -33,10 +33,11 @@ export default function cssInJs({ filename = 'vars.js' }: CssInJsOptions = {}): 
         const parts = token.id.split('.');
         const last = parts.pop()!;
         for (const next of parts) {
-          if (!(next in node)) {
-            node[camelCase(next)] = {};
+          const key = camelCase(next);
+          if (!(key in node)) {
+            node[key] = {};
           }
-          node = node[next];
+          node = node[key];
         }
 
         let tokenValue: any = `var(${token.localID})`;

--- a/packages/plugin-css-in-js/test/fixtures/dashed-paths/resolver.json
+++ b/packages/plugin-css-in-js/test/fixtures/dashed-paths/resolver.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
+  "version": "2025.10",
+  "resolutionOrder": [{ "$ref": "#/sets/base" }],
+  "sets": {
+    "base": {
+      "sources": [
+        {
+          "color": {
+            "accent": {
+              "$type": "color",
+              "bg": { "$value": "#2e5bff" },
+              "bg-hover": { "$value": "#1f48e0" },
+              "fg": { "$value": "#ffffff" }
+            }
+          },
+          "number": {
+            "line-height": {
+              "$type": "number",
+              "loose": { "$value": 1.75 },
+              "tight": { "$value": 1.15 }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/plugin-css-in-js/test/fixtures/dashed-paths/terrazzo.config.ts
+++ b/packages/plugin-css-in-js/test/fixtures/dashed-paths/terrazzo.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@terrazzo/cli";
+import css from '@terrazzo/plugin-css'
+import cssInJs from '../../../dist/index.js'
+
+export default defineConfig({
+  tokens: 'resolver.json',
+  outDir: '.',
+  plugins: [
+    css({ skipBuild: true }),
+    cssInJs({ filename: 'actual.js' }),
+  ],
+  lint: {
+    rules: {},
+  }
+});

--- a/packages/plugin-css-in-js/test/fixtures/dashed-paths/want.d.ts
+++ b/packages/plugin-css-in-js/test/fixtures/dashed-paths/want.d.ts
@@ -1,0 +1,13 @@
+export const color: {
+  "accent": {
+    "bg": string,
+    "bgHover": string,
+    "fg": string
+  }
+};
+export const number: {
+  "lineHeight": {
+    "loose": string,
+    "tight": string
+  }
+};

--- a/packages/plugin-css-in-js/test/fixtures/dashed-paths/want.js
+++ b/packages/plugin-css-in-js/test/fixtures/dashed-paths/want.js
@@ -1,0 +1,13 @@
+export const color = {
+  "accent": {
+    "bg": "var(--color-accent-bg)",
+    "bgHover": "var(--color-accent-bg-hover)",
+    "fg": "var(--color-accent-fg)"
+  }
+};
+export const number = {
+  "lineHeight": {
+    "loose": "var(--number-line-height-loose)",
+    "tight": "var(--number-line-height-tight)"
+  }
+};

--- a/packages/plugin-css-in-js/test/index.test.ts
+++ b/packages/plugin-css-in-js/test/index.test.ts
@@ -4,7 +4,7 @@ import { execaNode } from 'execa';
 import { describe, expect, it } from 'vitest';
 
 describe('plugin-css-in-js', () => {
-  const tests = ['typography'];
+  const tests = ['typography', 'dashed-paths'];
 
   it.each(tests)('%s', async (dir) => {
     const cwd = new URL(`./fixtures/${dir}/`, import.meta.url);


### PR DESCRIPTION
## Changes

The walker wrote `node[camelCase(next)]` but read `node[next]`, crashing on dashed DTCG paths (`color.accent.bg-hover`, `number.line-height.loose`). Aligns the read with the write.

## How to Review

Added tests and fixtures.
