### PR TITLE
fix: publish, bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: true
       - run: pnpm run lint
@@ -28,11 +28,11 @@ jobs:
         node-version: [24]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: true
       - run: pnpm exec playwright install
@@ -40,11 +40,11 @@ jobs:
   test-node-20:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: true
       - run: pnpm exec playwright install
@@ -57,11 +57,11 @@ jobs:
   # test-macos:
   #   runs-on: macos-latest
   #   steps:
-  #     - uses: actions/checkout@v5
+  #     - uses: actions/checkout@v6
   #     - uses: actions/setup-node@v6
   #       with:
   #         node-version: 24
-  #     - uses: pnpm/action-setup@v4
+  #     - uses: pnpm/action-setup@v6
   #       with:
   #         run_install: true
   #     - run: pnpm exec playwright install
@@ -69,11 +69,11 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: true
       - run: pnpm exec playwright install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: true
       - run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: changesets/action@v1
         with:
           version: pnpm run version
-          publish: pnpm exec changeset publish --dry-run
+          publish: pnpm exec changeset publish
           commit: "[ci] release"
           title: "[ci] release"
         env:

--- a/packages/plugin-tailwind/test/fixtures/variable-name/tailwind.want.css
+++ b/packages/plugin-tailwind/test/fixtures/variable-name/tailwind.want.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.2.1 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.2.4 | MIT License | https://tailwindcss.com */
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {


### PR DESCRIPTION
## Changes

Publish accidentally blocked by a failing test. Also removes `--dry-run` flag.

Unrelated: bumps GitHub Actions

## How to Review

- CI
