### PR TITLE
Do not provide listPermutations API for complex resolvers

### DIFF
--- a/packages/cli/src/shared.ts
+++ b/packages/cli/src/shared.ts
@@ -55,6 +55,7 @@ export async function loadConfig({ cmd, flags, logger }: LoadConfigOptions) {
       },
       alphabetize: false,
       ignore: { tokens: [], deprecated: false },
+      permutationLimit: 1000,
     };
     let configPath: string | undefined;
 

--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -26,6 +26,7 @@ export default function defineConfig(
   normalizePlugins({ config, logger });
   normalizeLint({ config, logger });
   normalizeIgnore({ config, logger });
+  normalizePermutationLimit({ config, logger });
 
   // 2. Start build by calling config()
   for (const plugin of config.plugins) {
@@ -281,6 +282,31 @@ function normalizeIgnore({ config, logger }: { config: ConfigInit; logger: Logge
       group: 'config',
       message: `ignore.deprecated: Expected boolean, received ${JSON.stringify(config.ignore.deprecated)}`,
     });
+  }
+}
+
+function normalizePermutationLimit({ config, logger }: { config: ConfigInit; logger: Logger }) {
+  if (config.permutationLimit === undefined) {
+    config.permutationLimit = 1000;
+  } else {
+    if (typeof config.permutationLimit !== 'number') {
+      logger.error({
+        group: 'config',
+        message: `permutationLimit: Expected number, received ${JSON.stringify(config.ignore.deprecated)}`,
+      });
+    }
+    if (config.permutationLimit < 0) {
+      logger.error({
+        group: 'config',
+        message: `permutationLimit: Permutation limit must be greater than or equal to zero, received ${config.permutationLimit}`,
+      });
+    }
+    if (config.permutationLimit === Number.POSITIVE_INFINITY) {
+      logger.warn({
+        group: 'config',
+        message: `permutationLimit: Permutation limit set to infinity; use listPermutations with caution.`,
+      });
+    }
   }
 }
 

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -177,7 +177,7 @@ export function createResolver(
     },
     source: resolverSource,
     listPermutations:
-      permutationCount < 1000
+      permutationCount <= config.permutationLimit
         ? () => {
             // only do work on first call, then cache subsequent work. this could be thousands of possible values!
             if (!allPermutations.length) {

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -120,6 +120,8 @@ export function createResolver(
     }
   }
 
+  const permutationCount = Object.values(validContexts).reduce((acc, context) => acc * context.length, 1);
+
   return {
     apply(inputRaw, options) {
       const tokensRaw: TokenNormalizedSet = {};
@@ -174,13 +176,16 @@ export function createResolver(
       return tokens;
     },
     source: resolverSource,
-    listPermutations() {
-      // only do work on first call, then cache subsequent work. this could be thousands of possible values!
-      if (!allPermutations.length) {
-        allPermutations.push(...calculatePermutations(Object.entries(validContexts)));
-      }
-      return allPermutations;
-    },
+    listPermutations:
+      permutationCount < 1000
+        ? () => {
+            // only do work on first call, then cache subsequent work. this could be thousands of possible values!
+            if (!allPermutations.length) {
+              allPermutations.push(...calculatePermutations(Object.entries(validContexts)));
+            }
+            return allPermutations;
+          }
+        : undefined,
     isValidInput(input, throwError = false) {
       if (!input || typeof input !== 'object') {
         logger.error({ group: 'resolver', message: `Invalid input: ${JSON.stringify(input)}.` });

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -359,8 +359,10 @@ export interface Resolver<
    * List all possible valid input combinations. Ignores default values, as they
    * would duplicate some other permutations. This also caches results, so it’s
    * only computed once on the first call.
+   *
+   * If the resolver is deemed to complex, this API is not provided.
    */
-  listPermutations: () => Input[];
+  listPermutations?: () => Input[];
   /* Generate a stable ID from any input */
   getPermutationID: (input: Input) => string;
   /** The original resolver document, simplified */

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -95,6 +95,14 @@ export interface Config {
     /** Ignore deprecated tokens */
     deprecated?: boolean;
   };
+  /**
+   * Set the maximum number of permutations before the listPermutations API is disabled.
+   *
+   * This is a safety feature to prevent denial of service issues on complex resolvers.
+   *
+   * @default 1000
+   */
+  permutationLimit?: number;
 }
 
 export interface VisitorContext {
@@ -145,6 +153,7 @@ export interface ConfigInit {
     tokens: NonNullable<NonNullable<Config['ignore']>['tokens']>;
     deprecated: NonNullable<NonNullable<Config['ignore']>['deprecated']>;
   };
+  permutationLimit: number;
 }
 
 export interface ConfigOptions {

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -450,7 +450,7 @@ describe('Resolver module', () => {
         }),
       });
 
-      expect(resolver?.listPermutations(), 'listPermutations()').toEqual([{ theme: 'light' }, { theme: 'dark' }]);
+      expect(resolver?.listPermutations?.(), 'listPermutations()').toEqual([{ theme: 'light' }, { theme: 'dark' }]);
       expect(resolver?.isValidInput({ theme: 'dark' }), 'isValidInput({theme: dark})').toBe(true);
       expect(resolver?.isValidInput({}), 'isValidInput({})').toBe(false);
       expect(resolver?.isValidInput({ theme: 'foobar' }), 'isValidInput({theme: foobar})').toBe(false);

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -458,6 +458,41 @@ describe('Resolver module', () => {
   });
 });
 
+describe('permutation limit', () => {
+  it('allows listPermutations for small resolvers', async () => {
+    const cwd = new URL('./fixtures/resolver/', import.meta.url);
+    const filename = new URL('example.resolver.json', cwd);
+    const config = defineConfig({}, { cwd });
+    const { resolver } = await parse(
+      [
+        {
+          filename,
+          src: await fs.readFile(filename, 'utf8'),
+        },
+      ],
+      { config },
+    );
+    expect(resolver.listPermutations).not.toBeUndefined();
+    expect(resolver.listPermutations!().length).toBe(2);
+  });
+
+  it('disables listPermutations for complex resolvers', async () => {
+    const cwd = new URL('./fixtures/resolver/', import.meta.url);
+    const filename = new URL('example.resolver.json', cwd);
+    const config = defineConfig({ permutationLimit: 1 }, { cwd });
+    const { resolver } = await parse(
+      [
+        {
+          filename,
+          src: await fs.readFile(filename, 'utf8'),
+        },
+      ],
+      { config },
+    );
+    expect(resolver.listPermutations).toBeUndefined();
+  });
+});
+
 describe('calculatePermutations', () => {
   it('zero modifiers', () => {
     expect(calculatePermutations([])).toEqual([{}]);

--- a/packages/plugin-js/src/build.ts
+++ b/packages/plugin-js/src/build.ts
@@ -30,15 +30,16 @@ export function buildJS({
   output += '\n';
 
   // 1. Permutations
-  const permutations = (contexts ? calculatePermutations(Object.entries(contexts)) : resolver.listPermutations()).map(
-    (value) => ({
-      value,
-      // Note: id MUST have modifiers sorted alphabetically, so we can index them shallowly
-      id: JSON.stringify(
-        Object.fromEntries(Object.entries(value).sort((a, b) => a[0].localeCompare(b[0], 'en-us', { numeric: true }))),
-      ),
-    }),
-  );
+  // todo: replace internal usage of listPermutations
+  const permutations = (
+    contexts ? calculatePermutations(Object.entries(contexts)) : (resolver.listPermutations?.() ?? [])
+  ).map((value) => ({
+    value,
+    // Note: id MUST have modifiers sorted alphabetically, so we can index them shallowly
+    id: JSON.stringify(
+      Object.fromEntries(Object.entries(value).sort((a, b) => a[0].localeCompare(b[0], 'en-us', { numeric: true }))),
+    ),
+  }));
   output += 'export const PERMUTATIONS = {\n';
   let permutationI = 1;
   for (const { value, id } of permutations) {


### PR DESCRIPTION
## Changes

- fixes #752

Obviously we should provide a way of configuring the limit, but this seems like the safest way of doing it. It's a breaking change, but at least it's a _visible_ breaking change rather than invisibly throwing an error or returning `[]`.
