### PR TITLE
Round CSS gradient stop positions to avoid IEEE-754 noise

### DIFF
--- a/.changeset/gradient-stop-float-precision.md
+++ b/.changeset/gradient-stop-float-precision.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/token-tools": patch
+---
+
+Round CSS gradient stop positions to 1/1000, dropping IEEE-754 artefacts like `55.00000000000001%`.

--- a/packages/token-tools/src/css/gradient.ts
+++ b/packages/token-tools/src/css/gradient.ts
@@ -30,7 +30,7 @@ export function transformGradient(
     positions.push(
       token.partialAliasOf?.[i]?.position
         ? transformAlias(tokensSet[token.partialAliasOf[i]!.position!]!)
-        : `${100 * position}%`,
+        : `${+(100 * position).toFixed(3)}%`,
     );
   }
 

--- a/packages/token-tools/test/css.test.ts
+++ b/packages/token-tools/test/css.test.ts
@@ -600,6 +600,60 @@ describe('transformGradient', () => {
         },
       },
     ],
+    [
+      'rounds IEEE-754 noise from naked `100 * position`',
+      {
+        given: [
+          {
+            $value: [
+              {
+                color: { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 },
+                position: 0,
+              },
+              {
+                color: { colorSpace: 'srgb', components: [0, 1, 0], alpha: 1 },
+                position: 0.55,
+              },
+              {
+                color: { colorSpace: 'srgb', components: [0, 0, 1], alpha: 1 },
+                position: 1,
+              },
+            ],
+          },
+          { tokensSet: {}, permutation: {} },
+        ],
+        want: {
+          success: 'rgb(100% 0% 0%) 0%, rgb(0% 100% 0%) 55%, rgb(0% 0% 100%) 100%',
+        },
+      },
+    ],
+    [
+      'preserves authored 3-decimal precision',
+      {
+        given: [
+          {
+            $value: [
+              {
+                color: { colorSpace: 'srgb', components: [0, 0, 0], alpha: 1 },
+                position: 0,
+              },
+              {
+                color: { colorSpace: 'srgb', components: [0.5, 0.5, 0.5], alpha: 1 },
+                position: 1 / 3,
+              },
+              {
+                color: { colorSpace: 'srgb', components: [1, 1, 1], alpha: 1 },
+                position: 1,
+              },
+            ],
+          },
+          { tokensSet: {}, permutation: {} },
+        ],
+        want: {
+          success: 'rgb(0% 0% 0%) 0%, rgb(50% 50% 50%) 33.333%, rgb(100% 100% 100%) 100%',
+        },
+      },
+    ],
   ];
   it.each(tests)('%s', (_, { given, want }) => {
     let result: typeof want.success;


### PR DESCRIPTION
## Changes

`transformGradient` emits each gradient stop position via raw `${100 * position}%`. IEEE-754 makes `0.55` land in CSS as `55.00000000000001%`. Switching to `${+(100 * position).toFixed(3)}%` rounds to 1/1000.

## How to Review

Two new tests in `packages/token-tools/test/css.test.ts` cover the noise-rounding case (`position: 0.55` → `55%`) and bounded precision (`position: 1/3` → `33.333%`). No fixture in `packages/*/test/fixtures/` uses a non-trivial position, so no plugin snapshots churn.

```sh
pnpm --filter @terrazzo/token-tools test
```