### PR TITLE
docs: Add Swatchbook page

### DIFF
--- a/www/src/config/pages.ts
+++ b/www/src/config/pages.ts
@@ -22,6 +22,7 @@ export const DOCS_NAV = [
       { url: '/docs/integrations/css-in-js/', title: 'CSS-in-JS' },
       { url: '/docs/integrations/sass/', title: 'Sass' },
       { url: '/docs/integrations/js/', title: 'JS/TS' },
+      { url: '/docs/integrations/storybook/', title: 'Storybook' },
       { url: '/docs/integrations/swift/', title: 'Swift' },
       { url: '/docs/integrations/tailwind/', title: 'Tailwind' },
       { url: '/docs/integrations/vanilla-extract/', title: 'Vanilla Extract' },

--- a/www/src/pages/docs/integrations/storybook.md
+++ b/www/src/pages/docs/integrations/storybook.md
@@ -1,0 +1,29 @@
+---
+title: Storybook
+layout: ../../../layouts/docs.astro
+---
+
+# Storybook
+
+Terrazzo doesn’t have an official Storybook integration, but check out these related projects from the community!
+
+## Swatchbook
+
+[Swatchbook](https://unpunnyfuns.github.io/swatchbook/) is a third-party Storybook plugin that is a visualizer for DTCG tokens based on Terrazzo, maintained by <a class="gh-user" href="https://github.com/unpunnyfuns"><img class="gh-avatar" src="https://avatars.githubusercontent.com/u/91497503?v=4" aria-hidden />@unpunnyfuns</a>.
+
+From the docs:
+
+> A Storybook addon and MDX doc blocks for visualizing [DTCG design tokens](https://designtokens.org), built on Terrazzo's parser. Your production build runs Terrazzo's CLI against the same DTCG source; swatchbook reads it too, inside Storybook, and keeps the two aligned.
+>
+> Two things in one package:
+>
+> - **Doc blocks.** React components for MDX: `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, and per-type previews for motion, shadow, border, gradient, stroke style.
+> - **A toolbar theme switcher.** One dropdown per modifier axis in your DTCG resolver. Flip mode, brand, contrast, density — whatever your system has — and tokens repaint live.
+>
+> If your existing stories already style with CSS variables, they'll pick up the switcher's flips automatically. That's mostly what the tool does.
+>
+> #### Who it's for
+>
+> Design-system authors with DTCG tokens, especially systems with more than one independent dimension (brand × mode, contrast × mode, density). If your system has exactly one dimension and no plans for more, [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes)' single-string-ID model is simpler and a better fit.
+
+[View Documentation](https://unpunnyfuns.github.io/swatchbook/)

--- a/www/src/styles/docs.css
+++ b/www/src/styles/docs.css
@@ -281,6 +281,27 @@
   tr:nth-of-type(even) td {
     background-color: var(--tz-color-bg-3);
   }
+
+  blockquote {
+    --padding: var(--tz-space-400);
+
+    background-color: color-mix(in oklab, var(--tz-color-base-blue-600), var(--tz-color-bg-1) 70%);
+    border-color: var(--tz-color-base-blue-600);
+    border-radius: var(--tz-radius-400);
+    border-style: solid;
+    border-width: 1px 1px 2.5px;
+    margin: 0;
+    padding: var(--padding);
+    width: 100%;
+
+    & > p:first-child {
+      margin-top: 0;
+    }
+
+    & > p:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .callout {


### PR DESCRIPTION
## Changes

Adds [Swatchbook](https://unpunnyfuns.github.io/swatchbook/) by @unpunnyfuns to the Terrazzo docs so others can find this cool project 🙂.


<img width="2814" height="1764" alt="CleanShot 2026-05-16 at 09 42 09@2x" src="https://github.com/user-attachments/assets/fcf94488-c733-4420-8a8e-9c48aa7f4b08" />

## How to Review

Just adds a page. @unpunnyfuns, please feel free to open PRs to adjust anything! I also didn’t spend too much time on the presentation, happy to adjust anything.