### PR TITLE
Allow partial application of input

### DIFF
--- a/.changeset/early-plants-make.md
+++ b/.changeset/early-plants-make.md
@@ -1,0 +1,8 @@
+---
+"@terrazzo/parser": minor
+---
+
+Add `resolveAliases` option to `resolver.apply` API
+
+Setting this option to `false` allows partial application of input to the resolver using the `sets` and
+`modifiers` options in the same API.

--- a/packages/parser/src/lib/resolver-utils.ts
+++ b/packages/parser/src/lib/resolver-utils.ts
@@ -40,6 +40,7 @@ export function getPermutationID(
           input: stableInput,
           sets: options?.sets?.sort(alphaComparator),
           modifiers: options?.modifiers?.sort(alphaComparator),
+          resolveAliases: options?.resolveAliases ?? true,
         }
       : stableInput,
   );

--- a/packages/parser/src/parse/process.ts
+++ b/packages/parser/src/parse/process.ts
@@ -70,37 +70,39 @@ export function processTokens(
     }
     return next;
   }
-  const inlineStart = performance.now();
-  traverse(rootSource.document, {
-    enter(node, _parent, rawPath) {
-      if (rawPath.includes('$extensions') || node.type !== 'Object') {
-        return;
-      }
-      const $ref = node.type === 'Object' ? getObjMember(node, '$ref') : undefined;
-      if (!$ref) {
-        return;
-      }
-      assertStringNode($ref, logger, {
-        ...entry,
-        message: 'Invalid $ref. Expected string.',
-        node: $ref,
-        src: rootSource.src,
-      });
-      const jsonID = encodeFragment(rawPath);
-      refMap[jsonID] = { filename: rootSource.filename.href, refChain: [$ref.value] };
-      const resolved = resolveRef($ref, refMap[jsonID]!.refChain);
-      if (resolved.type === 'Object') {
-        node.members.splice(
-          node.members.findIndex((m) => m.name.type === 'String' && m.name.value === '$ref'),
-          1,
-        );
-        replaceNode(node, mergeObjects(resolved, node));
-      } else {
-        replaceNode(node, resolved);
-      }
-    },
-  });
-  logger.debug({ ...entry, message: 'Inline aliases', timing: performance.now() - inlineStart });
+  if (shouldResolveAliases) {
+    const inlineStart = performance.now();
+    traverse(rootSource.document, {
+      enter(node, _parent, rawPath) {
+        if (rawPath.includes('$extensions') || node.type !== 'Object') {
+          return;
+        }
+        const $ref = node.type === 'Object' ? getObjMember(node, '$ref') : undefined;
+        if (!$ref) {
+          return;
+        }
+        assertStringNode($ref, logger, {
+          ...entry,
+          message: 'Invalid $ref. Expected string.',
+          node: $ref,
+          src: rootSource.src,
+        });
+        const jsonID = encodeFragment(rawPath);
+        refMap[jsonID] = { filename: rootSource.filename.href, refChain: [$ref.value] };
+        const resolved = resolveRef($ref, refMap[jsonID]!.refChain);
+        if (resolved.type === 'Object') {
+          node.members.splice(
+            node.members.findIndex((m) => m.name.type === 'String' && m.name.value === '$ref'),
+            1,
+          );
+          replaceNode(node, mergeObjects(resolved, node));
+        } else {
+          replaceNode(node, resolved);
+        }
+      },
+    });
+    logger.debug({ ...entry, message: 'Inline aliases', timing: performance.now() - inlineStart });
+  }
 
   // 2. Resolve $extends to discover any more additional tokens
   function flatten$extends(node: momoa.ObjectNode, chain: string[]) {

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -170,6 +170,7 @@ export function createResolver(
         logger,
         sourceByFilename: { [resolverSource._source.filename!.href]: rootSource },
         isResolver: true,
+        resolveAliases: options?.resolveAliases ?? true,
         sources,
       });
       resolverCache[permutationID] = tokens;

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -351,6 +351,7 @@ export type ResolverInput = Record<string, string>;
 export type ResolverApplicationOptions = {
   sets?: string[];
   modifiers?: string[];
+  resolveAliases?: boolean;
 };
 
 export interface Resolver<

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -349,9 +349,30 @@ export interface ReferenceObject {
 export type ResolverInput = Record<string, string>;
 
 export type ResolverApplicationOptions = {
-  sets?: string[];
-  modifiers?: string[];
+  /**
+   * Resolve DTCG aliases when applying the input.
+   *
+   * @default true
+   */
   resolveAliases?: boolean;
+  /**
+   * Limit input application only to the listed sets.
+   *
+   * In combination with `modifiers`, this will limit output to only
+   * tokens declared within the options given. If tokens are referenced by alises
+   * outside these options, the application will fail unless `resolveAliases` is
+   * set to false.
+   */
+  sets?: string[];
+  /**
+   * Limit input application only to the listed modifiers.
+   *
+   * In combination with `sets`, this will limit output to only
+   * tokens declared within the options given. If tokens are referenced by alises
+   * outside these options, the application will fail unless `resolveAliases` is
+   * set to false.
+   */
+  modifiers?: string[];
 };
 
 export interface Resolver<

--- a/packages/parser/test/fixtures/complex-resolver/modes.json
+++ b/packages/parser/test/fixtures/complex-resolver/modes.json
@@ -1,0 +1,19 @@
+{
+  "$type": "color",
+  "light": {
+    "orange": {
+      "$value": "{light-orange}"
+    },
+    "blue": {
+      "$value": "{light-blue}"
+    }
+  },
+  "dark": {
+    "orange": {
+      "$value": "{dark-orange}"
+    },
+    "blue": {
+      "$value": "{dark-blue}"
+    }
+  }
+}

--- a/packages/parser/test/fixtures/complex-resolver/primitives.json
+++ b/packages/parser/test/fixtures/complex-resolver/primitives.json
@@ -1,0 +1,35 @@
+{
+  "$type": "color",
+  "light-blue": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0.5625, 0.73046875, 1],
+      "alpha": 1,
+      "hex": "#8fbaff"
+    }
+  },
+  "dark-blue": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0.05078125, 0.16015625, 0.46875],
+      "alpha": 1,
+      "hex": "#0c2877"
+    }
+  },
+  "light-orange": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0.9765625, 0.83203125, 0.82421875],
+      "alpha": 1,
+      "hex": "#f9d4d2"
+    }
+  },
+  "dark-orange": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0.4765625, 0.1015625, 0.109375],
+      "alpha": 1,
+      "hex": "#79191b"
+    }
+  }
+}

--- a/packages/parser/test/fixtures/complex-resolver/resolver.json
+++ b/packages/parser/test/fixtures/complex-resolver/resolver.json
@@ -1,0 +1,30 @@
+{
+  "version": "2025.10",
+  "name": "orange-blue",
+  "sets": {
+    "primitives": {
+      "sources": [{ "$ref": "primitives.json" }]
+    }
+  },
+  "modifiers": {
+    "theme": {
+      "default": "orange",
+      "contexts": {
+        "orange": [{ "$ref": "themes.json#orange" }],
+        "blue": [{ "$ref": "themes.json#blue" }]
+      }
+    },
+    "mode": {
+      "default": "light",
+      "contexts": {
+        "light": [{ "$ref": "modes.json#light" }],
+        "dark": [{ "$ref": "modes.json#dark" }]
+      }
+    }
+  },
+  "resolutionOrder": [
+    { "$ref": "#/modifiers/theme" },
+    { "$ref": "#/modifiers/mode" },
+    { "$ref": "#/sets/primitives" }
+  ]
+}

--- a/packages/parser/test/fixtures/complex-resolver/themes.json
+++ b/packages/parser/test/fixtures/complex-resolver/themes.json
@@ -1,0 +1,13 @@
+{
+  "$type": "color",
+  "orange": {
+    "color": {
+      "$value": "{orange}"
+    }
+  },
+  "blue": {
+    "color": {
+      "$value": "{blue}"
+    }
+  }
+}

--- a/packages/parser/test/lib/resolver-utils.test.ts
+++ b/packages/parser/test/lib/resolver-utils.test.ts
@@ -81,6 +81,10 @@ it('getPermutationID', () => {
   expect(getPermutationID({})).toBe('{}');
 
   expect(getPermutationID({ a: 'A', b: 'B' }, { sets: ['d', 'c'], modifiers: ['y', 'x'] })).toBe(
-    '{"input":{"a":"A","b":"B"},"sets":["c","d"],"modifiers":["x","y"]}',
+    '{"input":{"a":"A","b":"B"},"sets":["c","d"],"modifiers":["x","y"],"resolveAliases":true}',
+  );
+
+  expect(getPermutationID({ a: 'A', b: 'B' }, { resolveAliases: false })).toBe(
+    '{"input":{"a":"A","b":"B"},"resolveAliases":false}',
   );
 });

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs/promises';
 import * as momoa from '@humanwhocodes/momoa';
 import stripAnsi from 'strip-ansi';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import defineConfig from '../src/config.js';
-import type { Resolver } from '../src/index.js';
 import Logger from '../src/logger.js';
 import parse from '../src/parse/index.js';
 import { calculatePermutations, validateResolver } from '../src/resolver/index.js';
@@ -460,9 +459,7 @@ describe('Resolver module', () => {
 });
 
 describe('partial application', () => {
-  let resolver: Resolver;
-
-  beforeEach(async () => {
+  async function loadResolver() {
     const cwd = new URL('./fixtures/complex-resolver/', import.meta.url);
     const filename = new URL('resolver.json', cwd);
     const config = defineConfig({}, { cwd });
@@ -475,15 +472,17 @@ describe('partial application', () => {
       ],
       { config },
     );
-    resolver = result.resolver;
-  });
+    return result.resolver;
+  }
 
   it('returns only tokens from a set', async () => {
+    const resolver = await loadResolver();
     const tokens = resolver.apply({}, { modifiers: [], sets: ['primitives'] });
     expect(new Set(Object.keys(tokens))).toEqual(new Set(['dark-blue', 'dark-orange', 'light-blue', 'light-orange']));
   });
 
   it('returns only tokens from a modifier', async () => {
+    const resolver = await loadResolver();
     // first try without disabling alias resolution - it should fail
     expect(() => resolver.apply({}, { modifiers: ['mode'], sets: [] })).toThrow('Could not resolve alias');
     // now with alias resolution disabled

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs/promises';
 import * as momoa from '@humanwhocodes/momoa';
 import stripAnsi from 'strip-ansi';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import defineConfig from '../src/config.js';
+import type { Resolver } from '../src/index.js';
 import Logger from '../src/logger.js';
 import parse from '../src/parse/index.js';
 import { calculatePermutations, validateResolver } from '../src/resolver/index.js';
@@ -455,6 +456,41 @@ describe('Resolver module', () => {
       expect(resolver?.isValidInput({}), 'isValidInput({})').toBe(false);
       expect(resolver?.isValidInput({ theme: 'foobar' }), 'isValidInput({theme: foobar})').toBe(false);
     });
+  });
+});
+
+describe('partial application', () => {
+  let resolver: Resolver;
+
+  beforeEach(async () => {
+    const cwd = new URL('./fixtures/complex-resolver/', import.meta.url);
+    const filename = new URL('resolver.json', cwd);
+    const config = defineConfig({}, { cwd });
+    const result = await parse(
+      [
+        {
+          filename,
+          src: await fs.readFile(filename, 'utf8'),
+        },
+      ],
+      { config },
+    );
+    resolver = result.resolver;
+  });
+
+  it('returns only tokens from a set', async () => {
+    const tokens = resolver.apply({}, { modifiers: [], sets: ['primitives'] });
+    expect(new Set(Object.keys(tokens))).toEqual(new Set(['dark-blue', 'dark-orange', 'light-blue', 'light-orange']));
+  });
+
+  it('returns only tokens from a modifier', async () => {
+    // first try without disabling alias resolution - it should fail
+    expect(() => resolver.apply({}, { modifiers: ['mode'], sets: [] })).toThrow('Could not resolve alias');
+    // now with alias resolution disabled
+    const modeTokens = resolver.apply({}, { modifiers: ['mode'], sets: [], resolveAliases: false });
+    expect(new Set(Object.keys(modeTokens))).toEqual(new Set(['blue', 'orange']));
+    const themeTokens = resolver.apply({}, { modifiers: ['theme'], sets: [], resolveAliases: false });
+    expect(new Set(Object.keys(themeTokens))).toEqual(new Set(['color']));
   });
 });
 

--- a/www/src/pages/docs/reference/js-api.md
+++ b/www/src/pages/docs/reference/js-api.md
@@ -270,14 +270,43 @@ import { createResolver, parse } from "@terrazzo/parser";
 const { resolver } = await parse(sources, { config });
 const r = createResolver(resolver);
 
-for (const input of r.inputPermutations) {
+for (const input of r.listPermutations() ?? [{}]) {
   r.apply(input); // tokens for this input
 }
 ```
 
-It’s up to you to specify all the permutations desired. `.getAllInputPermutations()` will return an array of all possible inputs for the specified modifiers.
+It’s up to you to specify all the permutations desired.
 
-If the resolver specified zero modifiers, the array will be `[{}]` so you can still produce at least 1 valid tokens set. Thus, it will never be an empty array.
+The `listPermutations` API will return an array of all possible inputs for the specified modifiers, if
+that list of inputs is less than the configured maximum (`permutationLimit`). This guards against combinatorial explosions
+in complex resolvers.
+
+If the resolver specified zero modifiers, the `listPermutations` will return `[{}]` so you can still produce at least 1 valid tokens set. Thus, it will never be an empty array.
+
+
+### Partial resolver application
+
+```ts
+import { createResolver, parse } from "@terrazzo/parser";
+
+const { resolver } = await parse(sources, { config });
+const r = createResolver(resolver);
+
+r.apply({ theme: 'light' }, { modifiers: ['theme'], resolveAlises: false });
+```
+
+It may be useful to apply an input to only a specific subset of tokens within the resolver.
+
+The second argument to `apply` is an object that allows you to specify to which sets or modifiers you
+wish to apply the input. This may offer a great time saving on repeated applications across
+multiple inputs.
+
+By default, `apply` will resolve DTCG aliases. If a only a subset of tokens are processed, this is likely
+to cause reference errors. Setting `resolveAliases` to `false` will return unresolved aliases and enable
+partial application.
+
+Note that `$extends` directives that reference tokens outside of the subset will fail to resolve
+regardless of the `resolveAlaises` setting.
 
 ### API
 
@@ -285,10 +314,10 @@ If the resolver specified zero modifiers, the array will be `[{}]` so you can st
 
 `createResolver(resolver)` returns a resolver with the following methods:
 
-| Name                  | Type                                                               | Description                                                                                                                                           |
-| :-------------------- | :----------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **apply**             | `(input: Record<string, string>) => TokensMap`                     | Apply [inputs](https://www.designtokens.org/tr/2025.10/resolver/#inputs) to the resolver.                                                             |
-| **inputPermutations** | `Record<string, string>[]`                                         | Get all valid inputs for all [modifiers](https://www.designtokens.org/tr/2025.10/resolver/#modifiers).                                                |
-| **isValidInput**      | `(input: Record<string, string>, throwError?: boolean) => boolean` | Returns a boolean value if a given input meets the resolver requirements. Optionally pass `true` for the 2nd param to throw errors with helpful info. |
-| **getPermutationID**  | `(input: Record<string, string>) => string`                        | Returns a stable, deterministic ID from an input. This can also be parsed by JSON back into a normalized input.                                       |
-| **source**            | Resolver                                                           | Original resolver, in case you want to manually verify something or implement new logic.                                                              |
+| Name                 | Type                                                                                 | Description                                                                                                                                           |
+|:---------------------|:-------------------------------------------------------------------------------------| :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **apply**            | `(input: Record<string, string>, options?: ResolverApplicationOptions) => TokensMap` | Apply [inputs](https://www.designtokens.org/tr/2025.10/resolver/#inputs) to the resolver.                                                             |
+| **listPermutations** | `() => Record<string, string>[]`                                                     | Get all valid inputs for all [modifiers](https://www.designtokens.org/tr/2025.10/resolver/#modifiers).                                                |
+| **isValidInput**     | `(input: Record<string, string>, throwError?: boolean) => boolean`                   | Returns a boolean value if a given input meets the resolver requirements. Optionally pass `true` for the 2nd param to throw errors with helpful info. |
+| **getPermutationID** | `(input: Record<string, string>) => string`                                          | Returns a stable, deterministic ID from an input. This can also be parsed by JSON back into a normalized input.                                       |
+| **source**           | Resolver                                                                             | Original resolver, in case you want to manually verify something or implement new logic.                                                              |


### PR DESCRIPTION
## Changes

- add `resolveAliases` option to `Resolver#apply` API
- ensure inline aliasing step respects resolveAlias

Why?

This now allows you to do:

```ts
const tokens = resolver.apply({}, { sets: ['a-set'], modifiers: [], resolveAliases: false });
```

and the result will contain _only_ tokens declared in `a-set`. The same is possible for modifiers.

This is of great benefit when writing plugins that need to output only the tokens declared in a given set/modifier (e.g., in the case of a css class per context per modifier).
