### PR TITLE
feat(plugin-js): register format-id transform for token-listing lookup

### DIFF
--- a/.changeset/plugin-js-get-transforms.md
+++ b/.changeset/plugin-js-get-transforms.md
@@ -1,0 +1,7 @@
+---
+"@terrazzo/plugin-js": minor
+---
+
+Register a `transform` hook on plugin-js so each token gets a transform entry under `format: "js"`. The transform's `localID` matches the token id; the `value` and `meta['token-listing'].name` carry a JS access expression like `tokens["color.brand.500"]`. This aligns plugin-js with the other format plugins (css/sass/swift/tailwind/vanilla-extract/css-in-js) which all register transforms, and lets plugin-token-listing populate the `js` row of its per-platform `names` map by name lookup the same way it does for the other plugins.
+
+No build-output change; the existing `build` hook is unchanged. Consumers not using token-listing see no functional difference.

--- a/packages/plugin-js/src/index.ts
+++ b/packages/plugin-js/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@terrazzo/parser';
 import { buildDTS, buildJS } from './build.js';
-import { DEFAULT_PROPERTIES, type JSPluginOptions } from './lib.js';
+import { DEFAULT_PROPERTIES, FORMAT_ID, type JSPluginOptions } from './lib.js';
 
 export * from './build.js';
 export * from './lib.js';
@@ -17,6 +17,23 @@ export default function pluginJS({
     config(_, context) {
       if (Array.isArray(userProperties) && !userProperties.length) {
         context.logger.error({ ...entry, message: 'properties option can’t be empty' });
+      }
+    },
+
+    // Register a JS-access-expression transform for each token so consumers
+    // (notably plugin-token-listing) can look up the identifier a token has
+    // in the generated JS module. plugin-js doesn't pre-transform values
+    // (see `build` below), so the `value` field mirrors the access expression
+    // rather than carrying a separately-resolved literal.
+    async transform({ tokens, setTransform }) {
+      for (const id of Object.keys(tokens)) {
+        const accessor = `tokens[${JSON.stringify(id)}]`;
+        setTransform(id, {
+          format: FORMAT_ID,
+          localID: id,
+          value: accessor,
+          meta: { 'token-listing': { name: accessor } },
+        });
       }
     },
 

--- a/packages/plugin-js/src/lib.ts
+++ b/packages/plugin-js/src/lib.ts
@@ -1,5 +1,7 @@
 import type { Token, TokenNormalized, TokenNormalizedSet } from '@terrazzo/parser';
 
+export const FORMAT_ID = 'js';
+
 export const DEFAULT_PROPERTIES: Set<keyof TokenNormalized> = new Set([
   '$type',
   '$value',


### PR DESCRIPTION
Aligns plugin-js with other plugins that register transforms via the parser's transform hook. Each token gets a transform entry under format: 'js' with localID = id and a 'token-listing'.name of `tokens[<id>]`. plugin-token-listing's getNameFromPlugin lookup then resolves @terrazzo/plugin-js → 'js' and populates the js row of names without any consumer-side glue.

The build hook is unchanged; consumers not using token-listing see no behaviour change.

## Changes

_What does this PR change? Link to any related issue(s)._

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_
