### PR TITLE
fix(plugin-sass): forward CSS plugin's localID in transform hook

### DIFF
--- a/.changeset/plugin-sass-forward-css-localid.md
+++ b/.changeset/plugin-sass-forward-css-localid.md
@@ -1,0 +1,9 @@
+---
+"@terrazzo/plugin-sass": patch
+---
+
+Forward the CSS plugin's `localID` when registering the sass transform, so any `variableName` customization (prefixes, casing) configured on plugin-css is honored by the generated `$__token-values` Sass map.
+
+Previously, plugin-sass's `transform` hook set `localID: token.id` (the dotted DTCG id), which `build.ts` then read via `getTransforms({ format: FORMAT_ID })` and turned into a CSS variable name from scratch — bypassing the CSS plugin's `variableName` and producing `var(--color-blue-40)` instead of `var(--pcl-color-blue-40)` in the main token-values map. The typography mixins map was unaffected because that loop queries `format: 'css'` directly.
+
+Regression introduced in 2.2.0 (PR #589) when the main loop in `build.ts` switched from `format: 'css'` to `format: FORMAT_ID`.

--- a/.changeset/plugin-sass-forward-css-localid.md
+++ b/.changeset/plugin-sass-forward-css-localid.md
@@ -4,6 +4,6 @@
 
 Forward the CSS plugin's `localID` when registering the sass transform, so any `variableName` customization (prefixes, casing) configured on plugin-css is honored by the generated `$__token-values` Sass map.
 
-Previously, plugin-sass's `transform` hook set `localID: token.id` (the dotted DTCG id), which `build.ts` then read via `getTransforms({ format: FORMAT_ID })` and turned into a CSS variable name from scratch — bypassing the CSS plugin's `variableName` and producing `var(--color-blue-40)` instead of `var(--pcl-color-blue-40)` in the main token-values map. The typography mixins map was unaffected because that loop queries `format: 'css'` directly.
+Previously, plugin-sass's `transform` hook set `localID: token.id` (the dotted DTCG id), which `build.ts` then read via `getTransforms({ format: FORMAT_ID })` and turned into a CSS variable name from scratch — bypassing the CSS plugin's `variableName` and producing `var(--color-blue)` instead of `var(--ds-color-blue)` (for a `variableName` configured with a `ds` prefix, as in the test fixtures) in the main token-values map. The typography mixins map was unaffected because that loop queries `format: 'css'` directly.
 
 Regression introduced in 2.2.0 (PR #589) when the main loop in `build.ts` switched from `format: 'css'` to `format: FORMAT_ID`.

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -36,7 +36,7 @@ Please install @terrazzo/plugin-css and follow setup to add to your config.`,
 
         setTransform(token.id, {
           format: FORMAT_ID,
-          localID: token.id,
+          localID: token.localID,
           value,
           meta: { 'token-listing': { name: listingName } },
         });

--- a/packages/plugin-sass/test/fixtures/basic/want.scss
+++ b/packages/plugin-sass/test/fixtures/basic/want.scss
@@ -6,20 +6,20 @@
 @use "sass:map";
 
 $__token-values: (
-  "border.std": var(--border-std),
-  "color.blue": var(--color-blue),
-  "color.green": var(--color-green),
-  "color.red": var(--color-red),
-  "color.redgreenblue": var(--color-redgreenblue),
-  "gradient.g-b": var(--gradient-g-b),
-  "shadow": var(--shadow),
-  "transition": var(--transition),
-  "typography.body": var(--typography-body),
-  "typography.callout": var(--typography-callout),
-  "typography.family.body": var(--typography-family-body),
-  "typography.family.heading": var(--typography-family-heading),
-  "typography.page-title": var(--typography-page-title),
-  "typography.subheading": var(--typography-subheading)
+  "border.std": var(--ds-border-std),
+  "color.blue": var(--ds-color-blue),
+  "color.green": var(--ds-color-green),
+  "color.red": var(--ds-color-red),
+  "color.redgreenblue": var(--ds-color-redgreenblue),
+  "gradient.g-b": var(--ds-gradient-g-b),
+  "shadow": var(--ds-shadow),
+  "transition": var(--ds-transition),
+  "typography.body": var(--ds-typography-body),
+  "typography.callout": var(--ds-typography-callout),
+  "typography.family.body": var(--ds-typography-family-body),
+  "typography.family.heading": var(--ds-typography-family-heading),
+  "typography.page-title": var(--ds-typography-page-title),
+  "typography.subheading": var(--ds-typography-subheading)
 );
 
 $__token-typography-mixins: (


### PR DESCRIPTION
## Summary

Fixes a regression in `@terrazzo/plugin-sass` where the CSS plugin's `variableName` customization (prefixes, casing) was not honored by the generated `$__token-values` Sass map.

plugin-sass's `transform` hook was setting `localID: token.id` (the dotted DTCG id), which `build.ts` then read via `getTransforms({ format: FORMAT_ID })` and turned into a CSS variable name from scratch — bypassing the CSS plugin's `variableName` and producing `var(--color-blue-40)` instead of `var(--ds-color-blue-40)`. The typography mixins map was unaffected because that loop queries `format: 'css'` directly.

Forwarding `token.localID` instead preserves any prefix or casing customization configured via `variableName` on plugin-css.

## Root cause

Regression introduced in 2.2.0 (PR #589) when the main loop in `build.ts` switched from `format: 'css'` to `format: FORMAT_ID`.

## Changes

- `packages/plugin-sass/src/index.ts`: forward `token.localID` instead of `token.id` in the `setTransform` call.
- Added changeset (`@terrazzo/plugin-sass`: patch).
