### PR TITLE
feat(plugin-token-listing): Allow multiple preview values

### DIFF
--- a/packages/plugin-token-listing/src/build.ts
+++ b/packages/plugin-token-listing/src/build.ts
@@ -1,7 +1,7 @@
 import type { Logger, ModeMap, Plugin, TokenNormalized, TransformParams } from '@terrazzo/parser';
 import type { TokenTransformed } from '@terrazzo/token-tools';
 import type { PlatformOption, TokenListing, TokenListingExtension, TokenListingPluginOptions } from './lib.js';
-import { computePreviewValue } from './utils/previewValue.js';
+import { computeCssPreviewValue } from './utils/preview.js';
 import mapValues from './utils/utils.js';
 
 export * from './lib.js';
@@ -130,11 +130,12 @@ export default function getBuild(options: TokenListingPluginOptions): Plugin['bu
       originalValue,
     };
 
-    const previewValue =
-      options.previewValue?.({ logger, mode, tokensSet, token }) ??
-      computePreviewValue({ logger, mode, tokensSet, token });
-    if (previewValue !== '') {
-      output.previewValue = previewValue;
+    const preview: TokenListingExtension['preview'] = options.preview?.({ logger, mode, tokensSet, token }) ?? {
+      css: computeCssPreviewValue({ logger, mode, tokensSet, token }),
+    };
+
+    if (preview && Object.values(preview).some((previewValue) => !!previewValue)) {
+      output.preview = preview;
     }
 
     const subtype = options.subtype?.({ logger, mode, tokensSet, token });

--- a/packages/plugin-token-listing/src/index.ts
+++ b/packages/plugin-token-listing/src/index.ts
@@ -3,6 +3,7 @@ import getBuild from './build.js';
 import type { TokenListingPluginOptions } from './lib.js';
 
 export * from './lib.js';
+export { computeCssPreviewValue } from './utils/preview.js';
 
 export default function tokenListingPlugin(options: TokenListingPluginOptions): Plugin {
   return {

--- a/packages/plugin-token-listing/src/lib.ts
+++ b/packages/plugin-token-listing/src/lib.ts
@@ -52,8 +52,8 @@ export interface TokenListingExtension {
     };
   };
 
-  /** Value that can be used to preview this token in a CSS engine. */
-  previewValue?: string | number;
+  /** Values that can be used to preview this token in arbitrary display engines (like css, jetpack compose, swift, figma, etc.) */
+  preview?: CustomPreviewValue;
 
   /** Original value of the token, with aliases preserved. */
   originalValue?:
@@ -133,6 +133,8 @@ export type Subtype =
   | 'borderWidth'
   | 'borderRadius';
 
+export type CustomPreviewValue = Record<string, string | undefined | Record<string, string | undefined>>;
+
 export interface TokenListingPluginOptions {
   /**
    * Where to output the listing files
@@ -177,7 +179,7 @@ export interface TokenListingPluginOptions {
    * @param token The token for which to compute a preview value.
    * @returns The computed preview value, or `undefined` to use the automatically computed one.
    */
-  previewValue?: (params: CustomFunctionParams) => string | number | undefined;
+  preview?: (params: CustomFunctionParams) => CustomPreviewValue;
 
   /**
    * Hook to compute subtypes for design tokens, e.g. to hint which colors are backgrounds, borders,

--- a/packages/plugin-token-listing/src/utils/preview.ts
+++ b/packages/plugin-token-listing/src/utils/preview.ts
@@ -18,7 +18,7 @@ function isCompositeTypography(computed: ReturnType<typeof transformCSSValue>): 
   );
 }
 
-export function computePreviewValue({
+export function computeCssPreviewValue({
   tokensSet,
   token,
   mode,

--- a/packages/plugin-token-listing/test/build.test.ts
+++ b/packages/plugin-token-listing/test/build.test.ts
@@ -3,7 +3,13 @@ import { fileURLToPath } from 'node:url';
 import { build, defineConfig, type Logger, type Plugin, parse } from '@terrazzo/parser';
 import css from '@terrazzo/plugin-css';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import listing, { type CustomFunctionParams, type ListedToken, type TokenListingPluginOptions } from '../src/index.js';
+import listing, {
+  type CustomFunctionParams,
+  computeCssPreviewValue,
+  type ListedToken,
+  type TokenListingPluginOptions,
+} from '../src/index.js';
+import { createMockToken } from './utils.js';
 
 describe('token-listing plugin - Node.js API', () => {
   const mockLogger: Logger = {
@@ -326,13 +332,13 @@ describe('token-listing plugin - Node.js API', () => {
     });
   });
 
-  describe('previewValue', () => {
+  describe('preview', () => {
     it('outputs preview values for color tokens', async () => {
       const options = { filename: 'actual.listing.json' };
       const output = await setupTest('./fixtures/build-default/', options);
 
       const listed = output.data.find((d: any) => d.$name === 'base.color.black');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe('#1f2328');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('#1f2328');
     });
 
     it('outputs preview values for dimension tokens', async () => {
@@ -340,7 +346,7 @@ describe('token-listing plugin - Node.js API', () => {
       const output = await setupTest('./fixtures/build-default/', options);
 
       const listed = output.data.find((d: any) => d.$name === 'base.size.32');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe('32px');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('32px');
     });
 
     it('outputs preview values for font-weight tokens', async () => {
@@ -349,7 +355,7 @@ describe('token-listing plugin - Node.js API', () => {
       const output = await setupTest('./fixtures/build-default/', options, [], src);
 
       const listed = output.data.find((d: any) => d.$name === 'typography.weight.extralight');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe('200');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('200');
     });
 
     it('outputs preview values for font-size tokens', async () => {
@@ -358,7 +364,7 @@ describe('token-listing plugin - Node.js API', () => {
       const output = await setupTest('./fixtures/build-default/', options, [], src);
 
       const listed = output.data.find((d: any) => d.$name === 'typography.scale.04');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe('1.25rem');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('1.25rem');
     });
 
     it('outputs preview values for font-family tokens', async () => {
@@ -367,7 +373,7 @@ describe('token-listing plugin - Node.js API', () => {
       const output = await setupTest('./fixtures/build-default/', options, [], src);
 
       const listed = output.data.find((d: any) => d.$name === 'typography.family.serif');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe('"noto serif", serif');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('"noto serif", serif');
     });
 
     it('outputs preview values for composite typography tokens', async () => {
@@ -375,21 +381,54 @@ describe('token-listing plugin - Node.js API', () => {
       const output = await setupTest('./fixtures/build-default/', options);
 
       const listed = output.data.find((d: any) => d.$name === 'text.subtitle.shorthand');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe(
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe(
         '400 20px/1.6 -apple-system, "BlinkMacSystemFont", "Segoe UI", "Noto Sans", "Helvetica", "Arial", sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
       );
     });
 
-    it('calls a custom previewValue function when passed', async () => {
-      const previewValue = vi.fn().mockImplementation(() => 'custom');
+    it('calls a custom preview function when passed', async () => {
+      const preview = vi.fn().mockImplementation(() => ({
+        css: 'custom',
+        swift: 'custom swift',
+        typescript: { fontSize: 'custom font size', fontWeight: 'custom font weight' },
+      }));
       const options = {
         filename: 'actual.listing.json',
-        previewValue,
+        preview,
       };
       const output = await setupTest('./fixtures/build-default/', options);
       const listed = output.data.find((d: any) => d.$name === 'base.color.black');
-      expect(listed.$extensions['app.terrazzo.listing'].previewValue).toBe('custom');
-      expect(previewValue).toHaveBeenCalledTimes(1294);
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('custom');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.swift).toBe('custom swift');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.typescript.fontSize).toBe('custom font size');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.typescript.fontWeight).toBe('custom font weight');
+      expect(preview).toHaveBeenCalledTimes(1294);
+    });
+
+    it('calls a custom preview function with the plugin CSS transform', async () => {
+      const mockValue = { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 };
+      const token = createMockToken(
+        'test.token',
+        'color',
+        {
+          '.': { $value: mockValue },
+        },
+        mockValue,
+      );
+
+      const preview = vi.fn().mockImplementation(() => ({
+        css: computeCssPreviewValue({ logger: mockLogger, mode: '.', tokensSet: { 'test.token': token }, token }),
+        swift: 'custom swift',
+      }));
+
+      const options = {
+        filename: 'actual.listing.json',
+        preview,
+      };
+      const output = await setupTest('./fixtures/build-default/', options);
+      const listed = output.data.find((d: any) => d.$name === 'base.color.black');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.css).toBe('#f00');
+      expect(listed.$extensions['app.terrazzo.listing'].preview.swift).toBe('custom swift');
     });
   });
 

--- a/packages/plugin-token-listing/test/fixtures/cli-config-outdir/styles/out/want.listing.json
+++ b/packages/plugin-token-listing/test/fixtures/cli-config-outdir/styles/out/want.listing.json
@@ -29,7 +29,9 @@
             ],
             "alpha": 1
           },
-          "previewValue": "#000",
+          "preview": {
+            "css": "#000"
+          },
           "source": {
             "resource": "file://<root>/styles/tokens.json",
             "loc": {

--- a/packages/plugin-token-listing/test/utils.test.ts
+++ b/packages/plugin-token-listing/test/utils.test.ts
@@ -1,7 +1,8 @@
 import type { Logger, TokenNormalized } from '@terrazzo/parser';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { computePreviewValue } from '../src/utils/previewValue.js';
+import { computeCssPreviewValue } from '../src/utils/preview.js';
 import { mapValues } from '../src/utils/utils.js';
+import { createMockToken } from './utils.js';
 
 describe('mapValues', () => {
   it('maps values and preserves keys', () => {
@@ -27,7 +28,7 @@ vi.mock('@terrazzo/token-tools/css', () => ({
   transformCSSValue: vi.fn(),
 }));
 
-describe('computePreviewValue', () => {
+describe('computeCssPreviewValue', () => {
   const mockLogger: Logger = {
     warn: vi.fn(),
     error: vi.fn(),
@@ -42,20 +43,6 @@ describe('computePreviewValue', () => {
     setLevel: vi.fn(),
     stats: vi.fn(),
   };
-
-  const createMockToken = (
-    id: string,
-    $type: any = 'color',
-    mode: any = { '.': { $value: 'test-value' } },
-  ): TokenNormalized =>
-    ({
-      id,
-      $type,
-      mode,
-      $description: undefined,
-      $extensions: undefined,
-      aliasOf: undefined,
-    }) as TokenNormalized;
 
   const mockTokensSet: Record<string, TokenNormalized> = {
     'color.primary': createMockToken('color.primary', 'color'),
@@ -72,7 +59,7 @@ describe('computePreviewValue', () => {
       vi.mocked(transformCSSValue).mockReturnValue('#ff0000');
 
       const token = createMockToken('color.red', 'color');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -86,7 +73,7 @@ describe('computePreviewValue', () => {
       vi.mocked(transformCSSValue).mockReturnValue('');
 
       const token = createMockToken('test.token', 'color');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -108,7 +95,7 @@ describe('computePreviewValue', () => {
       });
 
       const token = createMockToken('typography.heading', 'typography');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -125,7 +112,7 @@ describe('computePreviewValue', () => {
       });
 
       const token = createMockToken('typography.minimal', 'typography');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -142,7 +129,7 @@ describe('computePreviewValue', () => {
       });
 
       const token = createMockToken('typography.weight-only', 'typography');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -165,7 +152,7 @@ describe('computePreviewValue', () => {
       });
 
       const token = createMockToken('typography.weight-only', 'typography');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -194,7 +181,7 @@ describe('computePreviewValue', () => {
         dark: { $value: '#dark-color' },
       });
 
-      computePreviewValue({
+      computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         mode: 'dark',
@@ -213,7 +200,7 @@ describe('computePreviewValue', () => {
 
       const token = createMockToken('color.no-dark-mode', 'color');
 
-      computePreviewValue({
+      computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         mode: 'dark',
@@ -232,7 +219,7 @@ describe('computePreviewValue', () => {
 
       const token = createMockToken('color.default', 'color');
 
-      computePreviewValue({
+      computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -249,7 +236,7 @@ describe('computePreviewValue', () => {
       vi.mocked(transformCSSValue).mockReturnValue(unsupportedObject);
 
       const token = createMockToken('custom.token', 'custom');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -269,7 +256,7 @@ describe('computePreviewValue', () => {
       vi.mocked(transformCSSValue).mockReturnValue(shadowObject);
 
       const token = createMockToken('shadow.subtle', 'shadow');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -291,7 +278,7 @@ describe('computePreviewValue', () => {
 
       const token = createMockToken('color.alias', 'color');
 
-      computePreviewValue({
+      computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         logger: mockLogger,
@@ -320,7 +307,7 @@ describe('computePreviewValue', () => {
         dark: { $value: '#fff' },
       });
 
-      computePreviewValue({
+      computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         mode: 'light',
@@ -342,7 +329,7 @@ describe('computePreviewValue', () => {
       vi.mocked(transformCSSValue).mockReturnValue('#color');
 
       const token = createMockToken('isolated.token', 'color');
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: {},
         token,
         logger: mockLogger,
@@ -360,7 +347,7 @@ describe('computePreviewValue', () => {
 
       const token = createMockToken('token.empty-mode', 'color', {});
 
-      computePreviewValue({
+      computeCssPreviewValue({
         tokensSet: mockTokensSet,
         token,
         mode: 'nonexistent',
@@ -390,7 +377,7 @@ describe('computePreviewValue', () => {
         aliasOf: undefined,
       } as any;
 
-      const result = computePreviewValue({
+      const result = computeCssPreviewValue({
         tokensSet: {},
         token,
         logger: mockLogger,

--- a/packages/plugin-token-listing/test/utils.ts
+++ b/packages/plugin-token-listing/test/utils.ts
@@ -1,0 +1,18 @@
+import type { TokenNormalized } from '@terrazzo/token-tools';
+
+export function createMockToken(
+  id: string,
+  $type: any = 'color',
+  mode: any = { '.': { $value: 'test-value' } },
+  value: any = 'test-value',
+): TokenNormalized {
+  return {
+    id,
+    $type,
+    mode,
+    $value: value,
+    $description: undefined,
+    $extensions: undefined,
+    aliasOf: undefined,
+  } as TokenNormalized;
+}


### PR DESCRIPTION
We have an issue with my team where we wanted to display a Compose Color and a SwiftUI Color token name and be able to also display the color in a CSS compatible format on a documentation page. Currently `previewValue` seems to only handle transformation to CSS.

<img width="361" height="111" alt="Screenshot 2026-06-02 at 14 46 18" src="https://github.com/user-attachments/assets/188e689f-478a-4a8e-a549-b61eaaa34f59" />

The idea is to replace the current `previewValue` with a `preview` object that stores different name formats for different stacks.

## Changes

Add the ability to generate multiple preview values in order to preview different token format. 
Also exports the current `computePreviewValue` renamed to `computeCssPreviewValue` so that it can be used alongside a custom function.
