### PR TITLE
Fix setTransform for modifier-only tokens

### DIFF
--- a/.changeset/parser-resolver-input-transforms.md
+++ b/.changeset/parser-resolver-input-transforms.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/parser": patch
+---
+
+Fix `setTransform()` for resolver tokens that only exist in a non-default modifier input.

--- a/packages/parser/src/build/index.ts
+++ b/packages/parser/src/build/index.ts
@@ -122,14 +122,15 @@ export default async function build(
             });
             return;
           }
-          const token = tokens[id]!;
-          if (!token) {
-            logger.error({ group: 'plugin', label: plugin.name, message: `No token "${id}"` });
-          }
           const isLegacyModes = params.input && Object.keys(params.input).length === 1 && 'tzMode' in params.input;
           const permutationID =
             params.input && !isLegacyModes ? resolver.getPermutationID(params.input) : FALLBACK_PERMUTATION_ID;
           const mode = params.mode || (isLegacyModes && params.input.tzMode) || undefined;
+          const tokenSource = params.input && !isLegacyModes ? resolver.apply(params.input) : tokens;
+          const token = tokenSource[id]!;
+          if (!token) {
+            logger.error({ group: 'plugin', label: plugin.name, message: `No token "${id}"` });
+          }
           const cleanValue: TokenTransformed['value'] =
             typeof params.value === 'string' ? params.value : { ...(params.value as Record<string, string>) };
           validateTransformParams({

--- a/packages/parser/test/plugin.test.ts
+++ b/packages/parser/test/plugin.test.ts
@@ -96,6 +96,81 @@ describe('Plugin API', () => {
       );
     });
 
+    it('can setTransform for tokens only present in a resolver input', async () => {
+      const config = defineConfig(
+        {
+          plugins: [
+            {
+              name: 'my-plugin',
+              async transform({ setTransform }) {
+                setTransform('color.only.dark', { format: 'my-format', value: 'dark-value', input: { theme: 'dark' } });
+              },
+              async build({ getTransforms, outputFile }) {
+                const transform = getTransforms({
+                  id: 'color.only.dark',
+                  format: 'my-format',
+                  input: { theme: 'dark' },
+                })[0]!;
+                outputFile('file.txt', `${transform.value}:${transform.token.id}:${transform.token.$type}`);
+              },
+            },
+          ],
+        },
+        { cwd: new URL('file:///') },
+      );
+      const { sources, tokens, resolver } = await parse(
+        [
+          {
+            filename: new URL('file:///tokens.resolver.json'),
+            src: {
+              version: '2025.10',
+              modifiers: {
+                theme: {
+                  default: 'light',
+                  contexts: {
+                    light: [
+                      {
+                        color: {
+                          base: {
+                            $type: 'color',
+                            $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+                          },
+                        },
+                      },
+                    ],
+                    dark: [
+                      {
+                        color: {
+                          base: {
+                            $type: 'color',
+                            $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                          },
+                          only: {
+                            dark: {
+                              $type: 'color',
+                              $value: { colorSpace: 'srgb', components: [0.2, 0.2, 0.2] },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              resolutionOrder: [{ $ref: '#/modifiers/theme' }],
+            },
+          },
+        ],
+        { config },
+      );
+      expect(tokens['color.only.dark']).toBeUndefined();
+
+      const { outputFiles } = await build(tokens, { config, resolver, sources });
+      expect(outputFiles[0]).toEqual(
+        expect.objectContaining({ filename: 'file.txt', contents: 'dark-value:color.only.dark:color' }),
+      );
+    });
+
     it('default mode transform', async () => {
       const config = defineConfig(
         {


### PR DESCRIPTION
## Summary

Fixes #707.

`setTransform()` currently validates and stores transformed-token metadata from the base token set passed into `build()`. With a resolver, that base set is the default permutation, so a plugin cannot transform a token that only exists in a non-default modifier context even when it supplies `input` for that context.

This updates `setTransform()` to resolve token metadata from `resolver.apply(params.input)` for non-legacy resolver inputs, while preserving the existing base-token behavior for default and legacy `tzMode` transforms.

## Tests

- `corepack pnpm --filter @terrazzo/parser exec vitest run test/plugin.test.ts -t "resolver input"`
- `corepack pnpm --filter @terrazzo/parser run test`
- `corepack pnpm --filter @terrazzo/parser run lint:ts`
- `corepack pnpm exec biome check --formatter-enabled=false --diagnostic-level=error packages/parser`
- `corepack pnpm --filter @terrazzo/parser run build`
- `git diff --check`

Assisted-by: OpenAI Codex