### PR TITLE
Add resolver orthogonality metadata

### DIFF
--- a/.changeset/parser-resolver-orthogonality.md
+++ b/.changeset/parser-resolver-orthogonality.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/parser": patch
+---
+
+Expose `resolver.orthogonal` so downstream plugins can tell when resolver modifiers touch unique token IDs.

--- a/packages/parser/src/lib/resolver-utils.ts
+++ b/packages/parser/src/lib/resolver-utils.ts
@@ -66,7 +66,7 @@ export function destructiveMerge(a: object, b: object): void {
         (a as any)[k] = []; // arrays are overwritten; always make an empty one
         destructiveMerge((a as any)[k], [...b2]); // shallow copy
       } else {
-        if (!(k in a)) {
+        if (!(k in a) || (a as any)[k] == null || typeof (a as any)[k] !== 'object' || Array.isArray((a as any)[k])) {
           (a as any)[k] = {}; // objects are merged; create empty one if none exists
         }
         destructiveMerge((a as any)[k], { ...b2 }); // shallow copy

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -1,12 +1,19 @@
 import type * as momoa from '@humanwhocodes/momoa';
-import { type InputSource, type InputSourceWithDocument, maybeRawJSON } from '@terrazzo/json-schema-tools';
+import { type InputSource, type InputSourceWithDocument, maybeRawJSON, parseRef } from '@terrazzo/json-schema-tools';
 import type { TokenNormalizedSet } from '@terrazzo/token-tools';
 import type yamlToMomoa from 'yaml-to-momoa';
 import { toMomoa } from '../lib/momoa.js';
 import { destructiveMerge, getPermutationID } from '../lib/resolver-utils.js';
 import type Logger from '../logger.js';
 import { processTokens } from '../parse/process.js';
-import type { ConfigInit, Resolver, ResolverInput, ResolverSourceNormalized } from '../types.js';
+import { aliasToGroupRef } from '../parse/token.js';
+import type {
+  ConfigInit,
+  Resolver,
+  ResolverInput,
+  ResolverModifierNormalized,
+  ResolverSourceNormalized,
+} from '../types.js';
 import { normalizeResolver } from './normalize.js';
 import { isLikelyResolver, validateResolver } from './validate.js';
 
@@ -106,6 +113,7 @@ export function createResolver(
   const inputDefaults: ResolverInput = {};
   const validContexts: Record<string, string[]> = {};
   const allPermutations: ResolverInput[] = [];
+  const modifiers: ResolverModifierNormalized[] = [];
 
   const resolverCache: Record<string, any> = {};
 
@@ -117,12 +125,19 @@ export function createResolver(
         inputDefaults[m.name] = m.default!;
       }
       validContexts[m.name] = Object.keys(m.contexts);
+      modifiers.push(m);
     }
   }
 
   const permutationCount = Object.values(validContexts).reduce((acc, context) => acc * context.length, 1);
+  const defaultTokenSource = getDefaultTokenSource(resolverSource, inputDefaults);
+  const modifierTokenIDs = new Map(
+    modifiers.map((modifier) => [modifier.name, collectModifierTokenIDs(modifier, defaultTokenSource)]),
+  );
+  const orthogonal = areModifierTokenIDsOrthogonal(modifierTokenIDs);
 
   return {
+    orthogonal,
     apply(inputRaw, options) {
       const tokensRaw: TokenNormalizedSet = {};
       const input = { ...inputDefaults, ...inputRaw };
@@ -230,6 +245,110 @@ export function createResolver(
       return getPermutationID({ ...inputDefaults, ...input });
     },
   };
+}
+
+function getDefaultTokenSource(
+  resolverSource: ResolverSourceNormalized,
+  inputDefaults: ResolverInput,
+): Record<string, unknown> {
+  const tokensRaw: Record<string, unknown> = {};
+  for (const item of resolverSource.resolutionOrder) {
+    switch (item.type) {
+      case 'set': {
+        for (const source of item.sources) {
+          destructiveMerge(tokensRaw, source);
+        }
+        break;
+      }
+      case 'modifier': {
+        const context = inputDefaults[item.name] ?? Object.keys(item.contexts)[0]!;
+        for (const source of item.contexts[context] ?? []) {
+          destructiveMerge(tokensRaw, source);
+        }
+        break;
+      }
+    }
+  }
+  return tokensRaw;
+}
+
+function collectModifierTokenIDs(
+  modifier: ResolverModifierNormalized,
+  defaultTokenSource: Record<string, unknown>,
+): Set<string> {
+  const tokenIDs = new Set<string>();
+  for (const sources of Object.values(modifier.contexts)) {
+    const contextSource: Record<string, unknown> = {};
+    destructiveMerge(contextSource, defaultTokenSource);
+    for (const source of sources) {
+      destructiveMerge(contextSource, source);
+      collectTokenIDs(source, [], tokenIDs, contextSource);
+    }
+  }
+  return tokenIDs;
+}
+
+function collectTokenIDs(
+  source: unknown,
+  path: string[],
+  tokenIDs: Set<string>,
+  extendsSource: Record<string, unknown>,
+  extendsChain = new Set<string>(),
+): void {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return;
+  }
+  const sourceRecord = source as Record<string, unknown>;
+  if (typeof sourceRecord.$extends === 'string') {
+    const extended = resolveExtendedSource(sourceRecord.$extends, extendsSource);
+    if (extended && !extendsChain.has(sourceRecord.$extends)) {
+      extendsChain.add(sourceRecord.$extends);
+      collectTokenIDs(extended, path, tokenIDs, extendsSource, extendsChain);
+      extendsChain.delete(sourceRecord.$extends);
+    }
+  }
+  if (Object.hasOwn(source, '$value')) {
+    tokenIDs.add(path.join('.'));
+    return;
+  }
+  for (const [key, value] of Object.entries(source)) {
+    if (key.startsWith('$')) {
+      continue;
+    }
+    collectTokenIDs(value, [...path, key], tokenIDs, extendsSource, extendsChain);
+  }
+}
+
+function resolveExtendedSource($extends: string, source: Record<string, unknown>): unknown {
+  const ref = aliasToGroupRef($extends);
+  if (!ref) {
+    return;
+  }
+  return getPath(source, parseRef(ref.$ref).subpath ?? []);
+}
+
+function getPath(source: unknown, path: string[]): unknown {
+  let current = source;
+  for (const part of path) {
+    if (!current || typeof current !== 'object' || Array.isArray(current) || !Object.hasOwn(current, part)) {
+      return;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function areModifierTokenIDsOrthogonal(modifierTokenIDs: Map<string, Set<string>>): boolean {
+  const seenTokenIDs = new Set<string>();
+  for (const tokenIDs of modifierTokenIDs.values()) {
+    for (const tokenID of tokenIDs) {
+      if (seenTokenIDs.has(tokenID)) {
+        return false;
+      }
+      seenTokenIDs.add(tokenID);
+    }
+  }
+  return true;
 }
 
 /** Calculate all permutations */

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -376,6 +376,8 @@ export interface Resolver<
   getPermutationID: (input: Input) => string;
   /** The original resolver document, simplified */
   source: ResolverSourceNormalized;
+  /** Whether all resolver modifiers act on unique token IDs */
+  orthogonal: boolean;
   /** Helper function for permutations—see if a particular input is valid. Automatically applies default values. */
   isValidInput: (input: Input, throwError?: boolean) => boolean;
 }

--- a/packages/parser/test/lib/resolver-utils.test.ts
+++ b/packages/parser/test/lib/resolver-utils.test.ts
@@ -48,6 +48,8 @@ describe('descructiveMerge', () => {
     ],
     ['array: simple', { given: [{ a: [0] }, { a: [1, 2, 3] }], want: { a: [1, 2, 3] } }],
     ['array: nested object', { given: [{ a: [{ a: 1 }] }, { a: [{ b: 2 }] }], want: { a: [{ b: 2 }] } }],
+    ['object replaces primitive', { given: [{ a: 1 }, { a: { b: 2 } }], want: { a: { b: 2 } } }],
+    ['object replaces array', { given: [{ a: [1, 2] }, { a: { b: 2 } }], want: { a: { b: 2 } } }],
     ['null', { given: [{ a: { b: 1 } }, { a: { b: null } }], want: { a: { b: null } } }],
     [
       'nested array',

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -397,6 +397,177 @@ describe('Resolver module', () => {
         }),
       );
     });
+
+    it('marks resolvers orthogonal when modifiers touch unique token IDs', async () => {
+      const config = defineConfig({}, { cwd: new URL(import.meta.url) });
+      const { resolver } = await parse(
+        [
+          {
+            filename: new URL('file:///'),
+            src: JSON.stringify(
+              {
+                version: '2025.10',
+                resolutionOrder: [{ $ref: '#/modifiers/theme' }, { $ref: '#/modifiers/spacing' }],
+                modifiers: {
+                  theme: {
+                    contexts: {
+                      light: [
+                        {
+                          color: {
+                            bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+                          },
+                        },
+                      ],
+                      dark: [
+                        {
+                          color: {
+                            bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  spacing: {
+                    contexts: {
+                      compact: [{ space: { gap: { $type: 'dimension', $value: { value: 8, unit: 'px' } } } }],
+                      roomy: [{ space: { gap: { $type: 'dimension', $value: { value: 16, unit: 'px' } } } }],
+                    },
+                  },
+                },
+              },
+              undefined,
+              2,
+            ),
+          },
+        ],
+        { config },
+      );
+
+      expect(resolver.orthogonal).toBe(true);
+    });
+
+    it('marks resolvers non-orthogonal when modifiers touch the same token ID', async () => {
+      const config = defineConfig({}, { cwd: new URL(import.meta.url) });
+      const { resolver } = await parse(
+        [
+          {
+            filename: new URL('file:///'),
+            src: JSON.stringify(
+              {
+                version: '2025.10',
+                resolutionOrder: [{ $ref: '#/modifiers/theme' }, { $ref: '#/modifiers/contrast' }],
+                modifiers: {
+                  theme: {
+                    contexts: {
+                      light: [
+                        {
+                          color: {
+                            bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+                          },
+                        },
+                      ],
+                      dark: [
+                        {
+                          color: {
+                            bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  contrast: {
+                    contexts: {
+                      normal: [{}],
+                      high: [
+                        {
+                          color: {
+                            bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 0] } },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              undefined,
+              2,
+            ),
+          },
+        ],
+        { config },
+      );
+
+      expect(resolver.orthogonal).toBe(false);
+    });
+
+    it('counts extended tokens when checking modifier orthogonality', async () => {
+      const config = defineConfig({}, { cwd: new URL(import.meta.url) });
+      const { resolver } = await parse(
+        [
+          {
+            filename: new URL('file:///'),
+            src: JSON.stringify(
+              {
+                version: '2025.10',
+                sets: {
+                  base: {
+                    sources: [
+                      {
+                        component: {
+                          defaults: {
+                            bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+                            fg: { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+                resolutionOrder: [
+                  { $ref: '#/sets/base' },
+                  { $ref: '#/modifiers/theme' },
+                  { $ref: '#/modifiers/density' },
+                ],
+                modifiers: {
+                  theme: {
+                    contexts: {
+                      light: [
+                        {
+                          component: {
+                            button: {
+                              $extends: '{component.defaults}',
+                              bg: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  density: {
+                    contexts: {
+                      compact: [
+                        {
+                          component: {
+                            button: {
+                              $extends: '{component.defaults}',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              undefined,
+              2,
+            ),
+          },
+        ],
+        { config },
+      );
+
+      expect(resolver.orthogonal).toBe(false);
+    });
   });
 
   describe('additional cases', () => {


### PR DESCRIPTION
## Summary

Implements step 1 of #759.

This adds `resolver.orthogonal: boolean` to `@terrazzo/parser`. The value is computed once when the resolver is created by scanning token IDs touched by each modifier across all of its contexts:

- modifiers that touch disjoint token IDs -> `orthogonal: true`
- any token ID touched by more than one modifier -> `orthogonal: false`
- repeated IDs within the same modifier are allowed, since contexts of one modifier are mutually exclusive

This deliberately does not change CSS output yet. It exposes the parser metadata needed by downstream plugins to safely opt into modifier-scoped output later.

## Tests

- `corepack pnpm --filter @terrazzo/parser exec vitest run test/resolver.test.ts -t "orthogonal"`
- `corepack pnpm --filter @terrazzo/parser run test`
- `corepack pnpm --filter @terrazzo/parser run lint:ts`
- `corepack pnpm exec biome check --formatter-enabled=false --diagnostic-level=error packages/parser`
- `corepack pnpm --filter @terrazzo/parser run build`
- `git diff --check`

Assisted-by: OpenAI Codex