### PR TITLE
Add plugin-tailwind package metadata

### DIFF
--- a/.changeset/real-hoops-see.md
+++ b/.changeset/real-hoops-see.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-tailwind": patch
+---
+
+Add plugin-tailwind package metadata.

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/terrazzoapp/terrazzo.git",
     "directory": "packages/plugin-tailwind"
   },
+  "bugs": {
+    "url": "https://github.com/terrazzoapp/terrazzo/issues"
+  },
+  "homepage": "https://github.com/terrazzoapp/terrazzo#readme",
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
## Summary

Adds missing npm support metadata for `@terrazzo/plugin-tailwind`:

- `bugs.url` points to the Terrazzo issue tracker
- `homepage` points to the repository README

## Motivation

The package already publishes repository metadata, but npm consumers and registry tooling cannot currently discover the standard support and homepage links from the package manifest.

## Validation

```sh
node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/plugin-tailwind/package.json','utf8')); if(p.bugs?.url !== 'https://github.com/terrazzoapp/terrazzo/issues') throw new Error('missing bugs metadata'); if(p.homepage !== 'https://github.com/terrazzoapp/terrazzo#readme') throw new Error('missing homepage metadata'); console.log(JSON.stringify({name:p.name,homepage:p.homepage,bugs:p.bugs}, null, 2));"
git diff --check
```

`git diff --check` passed with only the local Windows line-ending warning.

AI-assisted with Codex; reviewed and validated before submission.