### PR TITLE
poc use tsc

### DIFF
--- a/.changeset/true-masks-ring.md
+++ b/.changeset/true-masks-ring.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/token-types": patch
+---
+
+Don't ship src files for @terrazzo/token-types

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .env
 .turbo
 .vitest-*
+*.tsbuildinfo

--- a/packages/token-tools/package.json
+++ b/packages/token-tools/package.json
@@ -30,13 +30,13 @@
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./css": "./dist/css.js",
-    "./js": "./dist/js.js",
+    "./css": "./dist/css/index.js",
+    "./js": "./dist/js/index.js",
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "format": "biome check --fix --unsafe .",
     "lint": "pnpm --filter @terrazzo/token-tools run \"/^lint:(js|ts)/\"",
     "lint:js": "biome check .",

--- a/packages/token-tools/rolldown.config.ts
+++ b/packages/token-tools/rolldown.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-    css: './src/css/index.ts',
-    js: './src/js/index.ts',
-  },
-});

--- a/packages/token-tools/tsconfig.build.json
+++ b/packages/token-tools/tsconfig.build.json
@@ -1,4 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["test"]
+  "extends": "../../tsconfig.build.json"
 }

--- a/packages/token-tools/tsconfig.json
+++ b/packages/token-tools/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
   "include": ["src", "test"]
 }

--- a/packages/token-types/.npmignore
+++ b/packages/token-types/.npmignore
@@ -1,0 +1,7 @@
+.turbo
+biome.*
+rolldown.*
+src/**
+test/**
+tsconfig.*
+vitest.*

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "${configDir}/dist",
+    "rootDir": "${configDir}/src"
+  },
+  "include":["${configDir}/src"],
+  "exclude": ["**/dist/*", "**/node_modules/*"]
+}


### PR DESCRIPTION
## Changes

Addresses #781 with a drive-by adding of missing `.npmignore`, and a switch to `tsc` for building instead of `rolldown`.
