### PR TITLE
Update to typescript 7; use for all non-bundled packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "stylelint-config-standard": "^40.0.0",
     "stylelint-order": "^8.1.1",
     "turbo": "^2.10.4",
-    "typescript": "^6.0.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.0",
+    "typescript-7": "npm:typescript@^7.0.2",
     "vite": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,8 +36,8 @@
     "terrazzo": "bin/cli.js"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack . && vite build",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/cli/rolldown.config.ts
+++ b/packages/cli/rolldown.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-  platform: 'node',
-});

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -13,7 +13,8 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "build": "rolldown -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit"

--- a/packages/icons/rolldown.config.ts
+++ b/packages/icons/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown.js';
-
-/** @type {import("rollup").InputOptions} */
-export default defineConfig({
-  input: 'src/index.tsx',
-  platform: 'browser',
-});

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "../../tsconfig.react.json",
-  "compilerOptions": {
-    "module": "nodenext",
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["src"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/json-schema-tools/package.json
+++ b/packages/json-schema-tools/package.json
@@ -31,9 +31,9 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "bench": "vitest bench",
-    "dev": "rolldown --watch -c",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/json-schema-tools/rolldown.config.ts
+++ b/packages/json-schema-tools/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/json-schema-tools/test/parse-ref.bench.ts
+++ b/packages/json-schema-tools/test/parse-ref.bench.ts
@@ -1,4 +1,4 @@
-import Pointer from '@apidevtools/json-schema-ref-parser/lib/pointer.js';
+import Pointer from '@apidevtools/json-schema-ref-parser/dist/lib/pointer.js';
 import { bench, describe } from 'vitest';
 
 import { parseRef } from '../src/index.js';

--- a/packages/json-schema-tools/tsconfig.build.json
+++ b/packages/json-schema-tools/tsconfig.build.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "lib": ["DOM", "ESNext"]
-  }
+  "extends": "../../tsconfig.build.json"
 }

--- a/packages/json-schema-tools/tsconfig.build.json
+++ b/packages/json-schema-tools/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ESNext"]
+  }
+}

--- a/packages/json-schema-tools/tsconfig.json
+++ b/packages/json-schema-tools/tsconfig.json
@@ -1,7 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"],
-    "lib": ["DOM", "ESNext"]
-  }
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/json-schema-tools/tsconfig.json
+++ b/packages/json-schema-tools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "types": ["node"],
     "lib": ["DOM", "ESNext"]
-  },
-  "include": ["src"]
+  }
 }

--- a/packages/json-schema-tools/tsconfig.json
+++ b/packages/json-schema-tools/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["DOM", "ESNext"],
-    "noEmit": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "lib": ["DOM", "ESNext"]
   },
   "include": ["src"]
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -34,8 +34,8 @@
     "directory": "./packages/parser/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "format": "oxfmt",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -38,7 +38,6 @@
     "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "format": "oxfmt",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/parser/rolldown.config.ts
+++ b/packages/parser/rolldown.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-  platform: 'node',
-});

--- a/packages/parser/tsconfig.build.json
+++ b/packages/parser/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node"]
-  }
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src", "test"],
-  "exclude": ["node_modules"]
+  "include": ["src", "test"]
 }

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -2,6 +2,5 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "types": ["node"]
-  },
-  "include": ["src", "test"]
+  }
 }

--- a/packages/plugin-css-in-js/package.json
+++ b/packages/plugin-css-in-js/package.json
@@ -36,8 +36,8 @@
     "directory": "./packages/plugin-js/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-css-in-js/rolldown.config.ts
+++ b/packages/plugin-css-in-js/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-css-in-js/tsconfig.build.json
+++ b/packages/plugin-css-in-js/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/plugin-css-in-js/tsconfig.json
+++ b/packages/plugin-css-in-js/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -27,8 +27,8 @@
     "directory": "./packages/plugin-css/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-css/rolldown.config.ts
+++ b/packages/plugin-css/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-css/tsconfig.build.json
+++ b/packages/plugin-css/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/plugin-css/tsconfig.json
+++ b/packages/plugin-css/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-js/package.json
+++ b/packages/plugin-js/package.json
@@ -28,8 +28,8 @@
     "directory": "./packages/plugin-js/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-js/rolldown.config.ts
+++ b/packages/plugin-js/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-js/test/index.test.ts
+++ b/packages/plugin-js/test/index.test.ts
@@ -116,7 +116,7 @@ color.$value.components satisfies (number | null)[];
         );
 
         const tsc = fileURLToPath(
-          new URL('../../../node_modules/typescript/bin/tsc', import.meta.url),
+          new URL('../../../node_modules/typescript-7/bin/tsc', import.meta.url),
         );
         await execaNode(tsc, ['-p', tmp]);
       } finally {

--- a/packages/plugin-js/tsconfig.build.json
+++ b/packages/plugin-js/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/plugin-js/tsconfig.json
+++ b/packages/plugin-js/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -27,8 +27,8 @@
     "directory": "packages/plugin-sass"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-sass/rolldown.config.ts
+++ b/packages/plugin-sass/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-sass/tsconfig.build.json
+++ b/packages/plugin-sass/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/plugin-sass/tsconfig.json
+++ b/packages/plugin-sass/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-swift/package.json
+++ b/packages/plugin-swift/package.json
@@ -28,8 +28,8 @@
     "directory": "./packages/plugin-swift/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-swift/rolldown.config.ts
+++ b/packages/plugin-swift/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-swift/test/index.test.ts
+++ b/packages/plugin-swift/test/index.test.ts
@@ -31,7 +31,7 @@ describe('@terrazzo/plugin-swift', () => {
     for (const { filename, contents } of result.outputFiles) {
       // oxlint-disable-next-line no-await-in-loop
       await expect(contents).toMatchFileSnapshot(fileURLToPath(new URL(filename, cwd)));
-      const { colors } = JSON.parse(contents) as {
+      const { colors } = JSON.parse(contents.toString()) as {
         colors?: { color?: { components?: Record<string, string> } }[];
       };
       for (const color of colors ?? []) {

--- a/packages/plugin-swift/tsconfig.build.json
+++ b/packages/plugin-swift/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/plugin-swift/tsconfig.json
+++ b/packages/plugin-swift/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -31,8 +31,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-tailwind/rolldown.config.ts
+++ b/packages/plugin-tailwind/rolldown.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-  platform: 'node',
-});

--- a/packages/plugin-tailwind/tsconfig.build.json
+++ b/packages/plugin-tailwind/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/plugin-tailwind/tsconfig.json
+++ b/packages/plugin-tailwind/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-token-listing/package.json
+++ b/packages/plugin-token-listing/package.json
@@ -27,8 +27,8 @@
     "directory": "./packages/plugin-token-listing/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-token-listing/rolldown.config.ts
+++ b/packages/plugin-token-listing/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-token-listing/tsconfig.build.json
+++ b/packages/plugin-token-listing/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/plugin-token-listing/tsconfig.json
+++ b/packages/plugin-token-listing/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/plugin-vanilla-extract/package.json
+++ b/packages/plugin-vanilla-extract/package.json
@@ -28,8 +28,8 @@
     "directory": "./packages/plugin-vanilla-extract/"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",

--- a/packages/plugin-vanilla-extract/package.json
+++ b/packages/plugin-vanilla-extract/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@terrazzo/cli": "workspace:^",
     "@terrazzo/parser": "workspace:^",
+    "@terrazzo/plugin-css": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vanilla-extract/css": "^1.21.1",

--- a/packages/plugin-vanilla-extract/rolldown.config.ts
+++ b/packages/plugin-vanilla-extract/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/plugin-vanilla-extract/tsconfig.build.json
+++ b/packages/plugin-vanilla-extract/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/plugin-vanilla-extract/tsconfig.json
+++ b/packages/plugin-vanilla-extract/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["./test/fixtures"]
 }

--- a/packages/plugin-vanilla-extract/tsconfig.json
+++ b/packages/plugin-vanilla-extract/tsconfig.json
@@ -1,11 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "lib": ["DOM", "ESNext"],
-    "outDir": "dist",
-    "types": ["node"]
-  },
-  "include": ["src", "test"],
-  "exclude": ["node_modules", "./test/fixtures/**"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/token-tools/tsconfig.json
+++ b/packages/token-tools/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/token-types/package.json
+++ b/packages/token-types/package.json
@@ -29,8 +29,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rolldown -c && attw --profile esm-only --pack .",
-    "dev": "rolldown -w -c",
+    "build": "tsc -b tsconfig.build.json && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit"

--- a/packages/token-types/rolldown.config.ts
+++ b/packages/token-types/rolldown.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from '../../rolldown';
-
-export default defineConfig({
-  input: {
-    index: './src/index.ts',
-  },
-});

--- a/packages/token-types/tsconfig.build.json
+++ b/packages/token-types/tsconfig.build.json
@@ -1,4 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["test"]
+  "extends": "../../tsconfig.build.json"
 }

--- a/packages/token-types/tsconfig.json
+++ b/packages/token-types/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
   "include": ["src", "test"]
 }

--- a/packages/token-types/tsconfig.json
+++ b/packages/token-types/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src", "test"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/use-color/package.json
+++ b/packages/use-color/package.json
@@ -24,11 +24,11 @@
     "directory": "./packages/use-color/"
   },
   "scripts": {
-    "build": "rolldown -c && size-limit && attw --profile esm-only --pack .",
-    "dev": "rolldown --watch -c",
+    "build": "tsc -b tsconfig.build.json && size-limit && attw --profile esm-only --pack .",
+    "dev": "tsc -b tsconfig.build.json -w",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "lint": "oxlint --quiet && oxfmt --check",
+    "lint": "oxlint --quiet && oxfmt --check && tsc --noEmit",
     "test": "vitest run"
   },
   "peerDependencies": {

--- a/packages/use-color/src/index.ts
+++ b/packages/use-color/src/index.ts
@@ -10,7 +10,7 @@ import {
   serialize,
   to as convert,
 } from 'colorjs.io/fn';
-import { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 /* oxlint-disable ban-ts-comment, no-accessor-recursion */
 
@@ -214,7 +214,9 @@ function isDifferent(a: ColorInput, b: ColorInput) {
 /**
  * memoize Color.js colors and reduce unnecessary updates
  */
-export default function useColor(color: ColorInput): [ColorOutput, (color: ColorInput) => void] {
+export default function useColor(
+  color: ColorInput,
+): [ColorOutput, React.Dispatch<React.SetStateAction<ColorInput>>] {
   const lastColor = useRef(color);
   const [innerColor, setInnerColor] = useState(() => parse(color));
 
@@ -223,17 +225,16 @@ export default function useColor(color: ColorInput): [ColorOutput, (color: Color
     lastColor.current = color;
   }
 
-  const setColorOutput = useCallback((newColor: React.SetStateAction<ColorInput>) => {
-    if (typeof newColor === 'function') {
-      newColor((value) => {
-        const next = parse(value);
-        setInnerColor(next);
-        return next.original;
-      });
-    } else if (newColor) {
-      setInnerColor(parse(newColor));
-    }
-  }, []);
+  const setColorOutput = useCallback<React.Dispatch<React.SetStateAction<ColorInput>>>(
+    (newColor) => {
+      if (typeof newColor === 'function') {
+        setInnerColor((value) => parse(newColor(value.original)));
+      } else if (newColor) {
+        setInnerColor(parse(newColor));
+      }
+    },
+    [],
+  );
 
   return [innerColor, setColorOutput];
 }

--- a/packages/use-color/tsconfig.build.json
+++ b/packages/use-color/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.build.json"
+}

--- a/packages/use-color/tsconfig.json
+++ b/packages/use-color/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "../../tsconfig.react.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["src"]
+  "extends": "../../tsconfig.base.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,25 +106,28 @@ importers:
         version: 1.1.4
       rolldown-plugin-dts:
         specifier: ^0.27.1
-        version: 0.27.1(oxc-resolver@11.23.0)(rolldown@1.1.4)(typescript@6.0.3)
+        version: 0.27.1(@typescript/typescript6@6.0.1)(oxc-resolver@11.23.0)(rolldown@1.1.4)
       strip-ansi:
         specifier: ^7.2.0
         version: 7.2.0
       stylelint:
         specifier: ^17.14.0
-        version: 17.14.0(typescript@6.0.3)
+        version: 17.14.0(@typescript/typescript6@6.0.1)
       stylelint-config-standard:
         specifier: ^40.0.0
-        version: 40.0.0(stylelint@17.14.0(typescript@6.0.3))
+        version: 40.0.0(stylelint@17.14.0(@typescript/typescript6@6.0.1))
       stylelint-order:
         specifier: ^8.1.1
-        version: 8.1.1(stylelint@17.14.0(typescript@6.0.3))
+        version: 8.1.1(stylelint@17.14.0(@typescript/typescript6@6.0.1))
       turbo:
         specifier: ^2.10.4
         version: 2.10.4
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.0
+        version: '@typescript/typescript6@6.0.1'
+      typescript-7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -461,7 +464,7 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^12.3.0
-        version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(@typescript/typescript6@6.0.1)(rollup@4.62.2)(tslib@2.8.1)
       '@size-limit/preset-small-lib':
         specifier: ^12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
@@ -515,7 +518,7 @@ importers:
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@storybook/react-vite':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@typescript/typescript6@6.0.1)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@terrazzo/fonts':
         specifier: workspace:^
         version: link:../fonts
@@ -594,7 +597,7 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^12.3.0
-        version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(@typescript/typescript6@6.0.1)(rollup@4.62.2)(tslib@2.8.1)
       '@size-limit/preset-small-lib':
         specifier: ^12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
@@ -688,7 +691,7 @@ importers:
         version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.1.1(@typescript/typescript6@6.0.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/token-tools:
     dependencies:
@@ -842,7 +845,7 @@ importers:
         version: 5.1.0
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 5.1.4(@typescript/typescript6@6.0.1)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
 packages:
 
@@ -3854,6 +3857,130 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.1':
+    resolution: {integrity: sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
@@ -6934,6 +7061,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
@@ -8804,13 +8936,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.4
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(@typescript/typescript6@6.0.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-docgen-typescript: 2.4.0(@typescript/typescript6@6.0.1)
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -9526,11 +9658,11 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-typescript@12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)':
+  '@rollup/plugin-typescript@12.3.0(@typescript/typescript6@6.0.1)(rollup@4.62.2)(tslib@2.8.1)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       resolve: 1.22.12
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
     optionalDependencies:
       rollup: 4.62.2
       tslib: 2.8.1
@@ -9800,12 +9932,12 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@typescript/typescript6@6.0.1)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(@typescript/typescript6@6.0.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@typescript/typescript6@6.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.7
@@ -9824,19 +9956,19 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(typescript@6.0.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@typescript/typescript6@6.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))
       react: 19.2.7
       react-docgen: 8.0.3
-      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-docgen-typescript: 2.4.0(@typescript/typescript6@6.0.1)
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
 
@@ -10087,6 +10219,70 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.1':
+    dependencies:
+      typescript: 6.0.3
 
   '@ungap/structured-clone@1.3.2': {}
 
@@ -10853,14 +11049,14 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
+  cosmiconfig@9.0.2(@typescript/typescript6@6.0.1):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
 
   cross-spawn@7.0.6:
     dependencies:
@@ -13125,9 +13321,9 @@ snapshots:
 
   radix3@1.1.2: {}
 
-  react-docgen-typescript@2.4.0(typescript@6.0.3):
+  react-docgen-typescript@2.4.0(@typescript/typescript6@6.0.1):
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
 
   react-docgen@8.0.3:
     dependencies:
@@ -13434,7 +13630,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.27.1(oxc-resolver@11.23.0)(rolldown@1.1.4)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.1(@typescript/typescript6@6.0.1)(oxc-resolver@11.23.0)(rolldown@1.1.4):
     dependencies:
       dts-resolver: 3.0.0(oxc-resolver@11.23.0)
       get-tsconfig: 5.0.0-beta.5
@@ -13444,7 +13640,7 @@ snapshots:
       yuku-codegen: 0.5.44
       yuku-parser: 0.5.44
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -13777,22 +13973,22 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylelint-config-recommended@18.0.0(stylelint@17.14.0(typescript@6.0.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.14.0(@typescript/typescript6@6.0.1)):
     dependencies:
-      stylelint: 17.14.0(typescript@6.0.3)
+      stylelint: 17.14.0(@typescript/typescript6@6.0.1)
 
-  stylelint-config-standard@40.0.0(stylelint@17.14.0(typescript@6.0.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.14.0(@typescript/typescript6@6.0.1)):
     dependencies:
-      stylelint: 17.14.0(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.14.0(typescript@6.0.3))
+      stylelint: 17.14.0(@typescript/typescript6@6.0.1)
+      stylelint-config-recommended: 18.0.0(stylelint@17.14.0(@typescript/typescript6@6.0.1))
 
-  stylelint-order@8.1.1(stylelint@17.14.0(typescript@6.0.3)):
+  stylelint-order@8.1.1(stylelint@17.14.0(@typescript/typescript6@6.0.1)):
     dependencies:
       postcss: 8.5.16
       postcss-sorting: 10.0.0(postcss@8.5.16)
-      stylelint: 17.14.0(typescript@6.0.3)
+      stylelint: 17.14.0(@typescript/typescript6@6.0.1)
 
-  stylelint@17.14.0(typescript@6.0.3):
+  stylelint@17.14.0(@typescript/typescript6@6.0.1):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -13802,7 +13998,7 @@ snapshots:
       '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.4)
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.4)
       colord: 2.9.3
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.1)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
       debug: 4.4.3
@@ -13938,9 +14134,9 @@ snapshots:
 
   ts-dedent@2.3.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.3):
+  tsconfck@3.1.6(@typescript/typescript6@6.0.1):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.1'
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -13966,6 +14162,29 @@ snapshots:
   typescript@5.6.1-rc: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ufo@1.6.4: {}
 
@@ -14158,22 +14377,22 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  vite-tsconfig-paths@5.1.4(@typescript/typescript6@6.0.1)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
+      tsconfck: 3.1.6(@typescript/typescript6@6.0.1)
     optionalDependencies:
       vite: 7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-tsconfig-paths@6.1.1(@typescript/typescript6@6.0.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
+      tsconfck: 3.1.6(@typescript/typescript6@6.0.1)
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,9 +409,6 @@ importers:
 
   packages/plugin-vanilla-extract:
     dependencies:
-      '@terrazzo/plugin-css':
-        specifier: workspace:^
-        version: link:../plugin-css
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -422,6 +419,9 @@ importers:
       '@terrazzo/parser':
         specifier: workspace:^
         version: link:../parser
+      '@terrazzo/plugin-css':
+        specifier: workspace:^
+        version: link:../plugin-css
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,29 @@ catalog:
   vitest: ^4.1.10
   yaml-to-momoa: 0.0.9
 
+minimumReleaseAgeExclude:
+  - '@typescript/typescript-aix-ppc64@7.0.2'
+  - '@typescript/typescript-darwin-arm64@7.0.2'
+  - '@typescript/typescript-darwin-x64@7.0.2'
+  - '@typescript/typescript-freebsd-arm64@7.0.2'
+  - '@typescript/typescript-freebsd-x64@7.0.2'
+  - '@typescript/typescript-linux-arm64@7.0.2'
+  - '@typescript/typescript-linux-arm@7.0.2'
+  - '@typescript/typescript-linux-loong64@7.0.2'
+  - '@typescript/typescript-linux-mips64el@7.0.2'
+  - '@typescript/typescript-linux-ppc64@7.0.2'
+  - '@typescript/typescript-linux-riscv64@7.0.2'
+  - '@typescript/typescript-linux-s390x@7.0.2'
+  - '@typescript/typescript-linux-x64@7.0.2'
+  - '@typescript/typescript-netbsd-arm64@7.0.2'
+  - '@typescript/typescript-netbsd-x64@7.0.2'
+  - '@typescript/typescript-openbsd-arm64@7.0.2'
+  - '@typescript/typescript-openbsd-x64@7.0.2'
+  - '@typescript/typescript-sunos-x64@7.0.2'
+  - '@typescript/typescript-win32-arm64@7.0.2'
+  - '@typescript/typescript-win32-x64@7.0.2'
+  - typescript@7.0.2
+
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,5 +20,6 @@
     "target": "ESNext",
     "verbatimModuleSyntax": true
   },
+  "include": ["${configDir}/src", "${configDir}/test"],
   "exclude": ["**/dist/*", "**/node_modules/*"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "jsx": "react-jsx",
     "module": "NodeNext",
     "moduleResolution": "nodenext",
@@ -18,6 +18,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "ESNext",
+    "types": ["node"],
     "verbatimModuleSyntax": true
   },
   "include": ["${configDir}/src", "${configDir}/test"],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "${configDir}/dist",
-    "rootDir": "${configDir}/src"
+    "rootDir": "${configDir}/src",
+    "types": []
   },
   "include": ["${configDir}/src"],
   "exclude": ["**/dist/*", "**/node_modules/*"]


### PR DESCRIPTION
## Changes

Switch to latest TS to get go version

## How to Review

It builds, I guess. There's a windows bug in the current version of turbo used so I'm going to do another PR updating that (and fixing any other windows-related build issues) before I start switching other packages to use tsc.
