### PR TITLE
Stop group properties cascading into a prefix-named sibling group

### DIFF
--- a/.changeset/group-cascade-sibling-prefix.md
+++ b/.changeset/group-cascade-sibling-prefix.md
@@ -1,0 +1,7 @@
+---
+"@terrazzo/parser": patch
+---
+
+Stop a group’s `$type`, `$deprecated`, and `$description` cascading into a sibling group whose name merely starts with the same characters, e.g. `size.font` leaking `fontFamily` into `size.font-scale`.
+
+Previously the cascade picked ancestors with a raw string prefix match on the group’s JSON pointer, so any group whose name began with a sibling’s name inherited that sibling’s properties. A `dimension` token under `size.font-scale` ended up with `$type: fontFamily` and failed validation, aborting the build.

--- a/packages/parser/src/parse/token.ts
+++ b/packages/parser/src/parse/token.ts
@@ -232,7 +232,10 @@ export function groupFromNode(
   const groupIDs = Object.keys(groups);
   groupIDs.sort(); // these may not be sorted; re-sort just in case (order determines final values)
   for (const groupID of groupIDs) {
-    const isParentGroup = jsonID.startsWith(groupID) && groupID !== jsonID;
+    // ⚠️ MUST compare with a trailing slash so the match ends at a path segment,
+    // otherwise sibling `size.font` looks like a parent of `size.font-scale`
+    const parentPrefix = groupID.endsWith('/') ? groupID : `${groupID}/`;
+    const isParentGroup = jsonID.startsWith(parentPrefix) && groupID !== jsonID;
     if (isParentGroup) {
       groups[jsonID].$deprecated = groups[groupID]?.$deprecated ?? groups[jsonID].$deprecated;
       groups[jsonID].$description = groups[groupID]?.$description ?? groups[jsonID].$description;

--- a/packages/parser/test/parse.test.ts
+++ b/packages/parser/test/parse.test.ts
@@ -558,6 +558,42 @@ describe('Additional cases', () => {
         tokens: ['color.blue.6', 'color.blue.7', 'color.blue.8', 'color.blue.9'],
       });
     });
+
+    it('doesn’t cascade into a sibling group with a shared name prefix', async () => {
+      const config = defineConfig({}, { cwd });
+      const { tokens } = await parse(
+        [
+          {
+            filename: DEFAULT_FILENAME,
+            src: {
+              $type: 'dimension',
+              size: {
+                font: {
+                  $type: 'fontFamily',
+                  $deprecated: 'Use typography.family instead',
+                  $description: 'Font stacks',
+                  base: { $value: 'Helvetica' },
+                },
+                'font-scale': {
+                  sm: { $value: { value: 0.75, unit: 'rem' } },
+                },
+              },
+            },
+          },
+        ],
+        { config },
+      );
+      expect(tokens['size.font-scale.sm']?.$type).toBe('dimension');
+      expect(tokens['size.font-scale.sm']?.$deprecated).toBe(undefined);
+      expect(tokens['size.font-scale.sm']?.group).toEqual({
+        id: 'size.font-scale',
+        $type: 'dimension',
+        $deprecated: undefined,
+        $description: undefined,
+        $extensions: undefined,
+        tokens: ['size.font-scale.sm'],
+      });
+    });
   });
 
   describe('$extensions', () => {


### PR DESCRIPTION
Closes #800.

### What

`groupFromNode()` copies each ancestor group's `$type`, `$deprecated` and `$description` down, and picks ancestors with a raw prefix match on the group's JSON pointer:

```ts
const isParentGroup = jsonID.startsWith(groupID) && groupID !== jsonID;
```

Nothing requires the match to end on a path segment, so `#/size/font` is treated as an ancestor of `#/size/font-scale`. A `dimension` token under `size.font-scale` inherits `fontFamily` from its sibling and fails `core/valid-font-family`, which aborts the build.

The fix compares against the group id plus a trailing slash instead.

### The `endsWith('/')` guard is load-bearing

`encodeFragment([])` returns `#/` for the root group, so a naive `${groupID}/` would produce `#//` and stop the root cascading at all — that breaks the existing `$type > inheritance works` test. The guard reuses `groupID` unchanged when it already ends in a slash.

I chose string arithmetic over comparing the `path` array that `groupFromNode` already receives, to keep the diff to the single condition. If you would rather it compared segments, say so and I will rewrite it that way.

### Tests

One case added to `packages/parser/test/parse.test.ts`, asserting the sibling token keeps `dimension`, that `$deprecated` did not leak, and the whole resolved `group` object. It fails on `main` with the `core/valid-font-family` error above and passes with the fix. The parser package is 267 passing.

### Notes on what I deliberately did not change

- The bug is order dependent — `size.font` must be entered before `size.font-scale` for the leak to exist, because groups are built during traversal. My test depends on that order, and would silently stop being a regression test if someone reordered the fixture keys. I did not add a second reversed-order case; tell me if you want one.
- A top-level group literally named `""` also encodes to `#/` and therefore collides with the root group. That is unchanged by this patch, and I left it alone rather than widen the diff.
- `$extensions` is in `GROUP_PROPERTIES` but has never been cascaded by this loop. I did not change that either — whether it should cascade looks like a separate decision.
- I did not test the YAML input path, `$extends` interaction with the cascade, or the multi-file bundle path for this scenario. The resolver, json-refs and extends tests all pass, but I wrote no new case for them.

A changeset is included.
