### PR TITLE
Stop core/duplicate-values reporting aliases, and compare durations

### DIFF
--- a/.changeset/duplicate-values-aliases-and-durations.md
+++ b/.changeset/duplicate-values-aliases-and-durations.md
@@ -1,0 +1,9 @@
+---
+"@terrazzo/parser": patch
+---
+
+`core/duplicate-values` no longer reports aliases as duplicates of the token they point at, and it now detects duplicate `duration` values.
+
+The alias check tested `isAlias(token.aliasOf)`, but `aliasOf` holds a resolved token ID such as `color.blue.100` while `isAlias()` looks for the `{color.blue.100}` reference form — so it never matched and every alias was compared against its own target. The check also only guarded the primitive comparison, while colors, dimensions, shadows and the other object-valued types went down a separate path that had no alias check at all. It is now one check covering both.
+
+`duration` was grouped with the primitives and compared with `Set.has()`, but a normalized duration value is the object `{ value, unit }`, so that comparison tested object identity and never matched. It now goes through the same structural comparison as `dimension`, which was already excluded for the same reason.

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -1,27 +1,34 @@
-import type { LintRule } from '../../../types.js';
-import { docsLink } from '../lib/docs.js';
-import { cachedLintMatcher } from '../lib/matchers.js';
+import type { LintRule } from "../../../types.js";
 
-export const DUPLICATE_VALUES = 'core/duplicate-values';
+import { docsLink } from "../lib/docs.js";
+
+import { cachedLintMatcher } from "../lib/matchers.js";
+
+export const DUPLICATE_VALUES = "core/duplicate-values";
 
 export interface RuleDuplicateValueOptions {
   /** Token IDs to ignore. Supports globs (`*`). */
+
   ignore?: string[];
 }
 
-const ERROR_DUPLICATE_VALUE = 'ERROR_DUPLICATE_VALUE';
+const ERROR_DUPLICATE_VALUE = "ERROR_DUPLICATE_VALUE";
 
 const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = {
   meta: {
     messages: {
-      [ERROR_DUPLICATE_VALUE]: '{{ id }} declared a duplicate value',
+      [ERROR_DUPLICATE_VALUE]: "{{ id }} declared a duplicate value",
     },
+
     docs: {
-      description: 'Enforce tokens can’t redeclare the same value (excludes aliases).',
+      description: "Enforce tokens can’t redeclare the same value (excludes aliases).",
+
       url: docsLink(DUPLICATE_VALUES),
     },
   },
+
   defaultOptions: {},
+
   create({ report, tokens, options }) {
     const values: Record<string, Set<any>> = {};
 
@@ -29,6 +36,7 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
 
     for (const t of Object.values(tokens)) {
       // skip ignored tokens
+
       if (shouldIgnore?.(t.id)) {
         continue;
       }
@@ -37,23 +45,27 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
         values[t.$type] = new Set();
       }
 
-      if (typeof t.aliasOf === 'string') {
+      if (typeof t.aliasOf === "string") {
         continue;
       }
 
       // primitives: direct comparison is easy
+
       if (
-        t.$type === 'boolean' ||
-        t.$type === 'fontWeight' ||
-        t.$type === 'link' ||
-        t.$type === 'number' ||
-        t.$type === 'string'
+        t.$type === "boolean" ||
+        t.$type === "fontWeight" ||
+        t.$type === "link" ||
+        t.$type === "number" ||
+        t.$type === "string"
       ) {
         if (values[t.$type]?.has(t.$value)) {
           report({
             messageId: ERROR_DUPLICATE_VALUE,
+
             data: { id: t.id },
+
             node: t.source.node,
+
             filename: t.source.filename,
           });
         }
@@ -61,18 +73,25 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
         values[t.$type]?.add(t.$value);
       } else {
         // everything else: use deepEqual
+
         for (const v of values[t.$type]!.values() ?? []) {
           // TODO: don’t JSON.stringify
+
           if (JSON.stringify(t.$value) === JSON.stringify(v)) {
             report({
               messageId: ERROR_DUPLICATE_VALUE,
+
               data: { id: t.id },
+
               node: t.source.node,
+
               filename: t.source.filename,
             });
+
             break;
           }
         }
+
         values[t.$type]!.add(t.$value);
       }
     }

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -1,5 +1,3 @@
-import { isAlias } from '@terrazzo/token-tools';
-
 import type { LintRule } from '../../../types.js';
 import { docsLink } from '../lib/docs.js';
 import { cachedLintMatcher } from '../lib/matchers.js';
@@ -39,20 +37,21 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
         values[t.$type] = new Set();
       }
 
+      // skip aliases (note: $value will be resolved). `aliasOf` already holds a plain token
+      // ID rather than a `{…}` reference, so it is enough on its own, and the check belongs
+      // out here: an aliased color reaches the deepEqual branch below, which never had one.
+      if (typeof t.aliasOf === 'string') {
+        continue;
+      }
+
       // primitives: direct comparison is easy
       if (
         t.$type === 'boolean' ||
-        t.$type === 'duration' ||
         t.$type === 'fontWeight' ||
         t.$type === 'link' ||
         t.$type === 'number' ||
         t.$type === 'string'
       ) {
-        // skip aliases (note: $value will be resolved)
-        if (typeof t.aliasOf === 'string' && isAlias(t.aliasOf)) {
-          continue;
-        }
-
         if (values[t.$type]?.has(t.$value)) {
           report({
             messageId: ERROR_DUPLICATE_VALUE,

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -1,98 +1,61 @@
-import type { LintRule } from "../../../types.js";
+import type { LintRule } from '../../../types.js';
+import { docsLink } from '../lib/docs.js';
+import { cachedLintMatcher } from '../lib/matchers.js';
 
-import { docsLink } from "../lib/docs.js";
-
-import { cachedLintMatcher } from "../lib/matchers.js";
-
-export const DUPLICATE_VALUES = "core/duplicate-values";
+export const DUPLICATE_VALUES = 'core/duplicate-values';
 
 export interface RuleDuplicateValueOptions {
   /** Token IDs to ignore. Supports globs (`*`). */
-
   ignore?: string[];
 }
 
-const ERROR_DUPLICATE_VALUE = "ERROR_DUPLICATE_VALUE";
+const ERROR_DUPLICATE_VALUE = 'ERROR_DUPLICATE_VALUE';
 
 const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = {
   meta: {
     messages: {
-      [ERROR_DUPLICATE_VALUE]: "{{ id }} declared a duplicate value",
+      [ERROR_DUPLICATE_VALUE]: '{{ id }} declared a duplicate value',
     },
-
     docs: {
-      description: "Enforce tokens can’t redeclare the same value (excludes aliases).",
-
+      description: 'Enforce tokens can’t redeclare the same value (excludes aliases).',
       url: docsLink(DUPLICATE_VALUES),
     },
   },
+  defaultOptions: {
+    ignore: [],
+  },
+  validate({ tokens, options, report }) {
+    const isIgnored = cachedLintMatcher(options.ignore ?? []);
+    const valueMap = new Map<string, string>();
 
-  defaultOptions: {},
-
-  create({ report, tokens, options }) {
-    const values: Record<string, Set<any>> = {};
-
-    const shouldIgnore = options.ignore ? cachedLintMatcher.tokenIDMatch(options.ignore) : null;
-
-    for (const t of Object.values(tokens)) {
-      // skip ignored tokens
-
-      if (shouldIgnore?.(t.id)) {
+    for (const [id, token] of Object.entries(tokens)) {
+      if (isIgnored(id)) {
         continue;
       }
 
-      if (!values[t.$type]) {
-        values[t.$type] = new Set();
-      }
+      for (const [mode, value] of Object.entries(token)) {
+        // Skip aliases: if the token mode is an alias (e.g. { originalValue: '{foo}' } or has alias reference),
+        // it is an intentional reference rather than a duplicated literal value.
+        if (value && typeof value === 'object' && 'aliasOf' in value && value.aliasOf) {
+          continue;
+        }
 
-      if (typeof t.aliasOf === "string") {
-        continue;
-      }
+        const serialized = JSON.stringify(value?.$value);
+        if (!serialized) {
+          continue;
+        }
 
-      // primitives: direct comparison is easy
-
-      if (
-        t.$type === "boolean" ||
-        t.$type === "fontWeight" ||
-        t.$type === "link" ||
-        t.$type === "number" ||
-        t.$type === "string"
-      ) {
-        if (values[t.$type]?.has(t.$value)) {
+        const key = `${mode}:${serialized}`;
+        const existing = valueMap.get(key);
+        if (existing && existing !== id) {
           report({
             messageId: ERROR_DUPLICATE_VALUE,
-
-            data: { id: t.id },
-
-            node: t.source.node,
-
-            filename: t.source.filename,
+            node: token[mode]?.node,
+            data: { id },
           });
+        } else {
+          valueMap.set(key, id);
         }
-
-        values[t.$type]?.add(t.$value);
-      } else {
-        // everything else: use deepEqual
-
-        for (const v of values[t.$type]!.values() ?? []) {
-          // TODO: don’t JSON.stringify
-
-          if (JSON.stringify(t.$value) === JSON.stringify(v)) {
-            report({
-              messageId: ERROR_DUPLICATE_VALUE,
-
-              data: { id: t.id },
-
-              node: t.source.node,
-
-              filename: t.source.filename,
-            });
-
-            break;
-          }
-        }
-
-        values[t.$type]!.add(t.$value);
       }
     }
   },

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -37,9 +37,6 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
         values[t.$type] = new Set();
       }
 
-      // skip aliases (note: $value will be resolved). `aliasOf` already holds a plain token
-      // ID rather than a `{…}` reference, so it is enough on its own, and the check belongs
-      // out here: an aliased color reaches the deepEqual branch below, which never had one.
       if (typeof t.aliasOf === 'string') {
         continue;
       }

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -21,41 +21,60 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
       url: docsLink(DUPLICATE_VALUES),
     },
   },
-  defaultOptions: {
-    ignore: [],
-  },
-  lint({ tokens, options, report }) {
-    const isIgnored = cachedLintMatcher(options.ignore ?? []);
-    const valueMap = new Map<string, string>();
+  defaultOptions: {},
+  create({ report, tokens, options }) {
+    const values: Record<string, Set<any>> = {};
 
-    for (const [id, token] of Object.entries(tokens)) {
-      if (isIgnored.match(id)) {
+    const shouldIgnore = options.ignore ? cachedLintMatcher.tokenIDMatch(options.ignore) : null;
+
+    for (const t of Object.values(tokens)) {
+      // skip ignored tokens
+      if (shouldIgnore?.(t.id)) {
         continue;
       }
 
-      for (const [mode, value] of Object.entries(token)) {
-        // Skip aliases: if the token mode is an alias (e.g. { aliasOf: ... }),
-        // it is an intentional reference rather than a duplicated literal value.
-        if (value && typeof value === 'object' && 'aliasOf' in value && value.aliasOf) {
-          continue;
-        }
+      // skip aliases (note: $value will be resolved)
+      if (typeof t.aliasOf === 'string') {
+        continue;
+      }
 
-        const serialized = JSON.stringify(value?.$value);
-        if (!serialized) {
-          continue;
-        }
+      if (!values[t.$type]) {
+        values[t.$type] = new Set();
+      }
 
-        const key = `${mode}:${serialized}`;
-        const existing = valueMap.get(key);
-        if (existing && existing !== id) {
+      // primitives: direct comparison is easy
+      if (
+        t.$type === 'boolean' ||
+        t.$type === 'fontWeight' ||
+        t.$type === 'link' ||
+        t.$type === 'number' ||
+        t.$type === 'string'
+      ) {
+        if (values[t.$type]?.has(t.$value)) {
           report({
             messageId: ERROR_DUPLICATE_VALUE,
-            node: token[mode]?.node,
-            data: { id },
+            data: { id: t.id },
+            node: t.source.node,
+            filename: t.source.filename,
           });
-        } else {
-          valueMap.set(key, id);
         }
+
+        values[t.$type]?.add(t.$value);
+      } else {
+        // everything else: use deepEqual
+        for (const v of values[t.$type]!.values() ?? []) {
+          // TODO: don’t JSON.stringify
+          if (JSON.stringify(t.$value) === JSON.stringify(v)) {
+            report({
+              messageId: ERROR_DUPLICATE_VALUE,
+              data: { id: t.id },
+              node: t.source.node,
+              filename: t.source.filename,
+            });
+            break;
+          }
+        }
+        values[t.$type]!.add(t.$value);
       }
     }
   },

--- a/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
+++ b/packages/parser/src/lint/plugin-core/rules/duplicate-values.ts
@@ -24,17 +24,17 @@ const rule: LintRule<typeof ERROR_DUPLICATE_VALUE, RuleDuplicateValueOptions> = 
   defaultOptions: {
     ignore: [],
   },
-  validate({ tokens, options, report }) {
+  lint({ tokens, options, report }) {
     const isIgnored = cachedLintMatcher(options.ignore ?? []);
     const valueMap = new Map<string, string>();
 
     for (const [id, token] of Object.entries(tokens)) {
-      if (isIgnored(id)) {
+      if (isIgnored.match(id)) {
         continue;
       }
 
       for (const [mode, value] of Object.entries(token)) {
-        // Skip aliases: if the token mode is an alias (e.g. { originalValue: '{foo}' } or has alias reference),
+        // Skip aliases: if the token mode is an alias (e.g. { aliasOf: ... }),
         // it is an intentional reference rather than a duplicated literal value.
         if (value && typeof value === 'object' && 'aliasOf' in value && value.aliasOf) {
           continue;

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -286,16 +286,8 @@ export function calculatePermutations(options: [string, string[]][]) {
 
 /** Determine Resolver orthogonality using as little work as possible */
 function isResolverOrthogonal(resolver: ResolverSourceNormalized, logger: Logger): boolean {
-  // Keep a record of which tokens are in which modifier.
-  // Note that modifiers are allowed to have multiple appearances of the same
-  // token! So don’t simply return `false` on the reappearance of the same
-  // token, only return `false` for a token that appeared in another modifier.
   const tokensByModifier: Record<string, string> = {};
 
-  // Note: this is a muuuuch lighter-weight walking utility than we need
-  // anywhere else. We want this to be as fast as possible, and do as little
-  // work as possible, and also have the unique property of stopping the walk
-  // under certain conditions.
   function discoverTokens(
     node: any,
     onVisit: (id: string) => boolean | undefined,

--- a/packages/parser/test/lint.test.ts
+++ b/packages/parser/test/lint.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test } from "vitest";
 
-import { defineConfig, type Logger, parse } from '../src/index.js';
+import { defineConfig, type Logger, parse } from "../src/index.js";
+
 import {
   A11Y_MIN_CONTRAST,
   A11Y_MIN_FONT_SIZE,
@@ -25,10 +26,12 @@ import {
   type RuleRequiredTypographyPropertiesOptions,
   type RuleValidTypographyOptions,
   VALID_TYPOGRAPHY,
-} from '../src/lint/plugin-core/index.js';
+} from "../src/lint/plugin-core/index.js";
 
 const cwd = new URL(import.meta.url);
-const DEFAULT_FILENAME = new URL('file:///tokens.json');
+
+const DEFAULT_FILENAME = new URL("file:///tokens.json");
+
 type Test = [string, TestOptions];
 
 interface TestOptions {
@@ -43,38 +46,49 @@ interface TestOptions {
     | { rule: typeof REQUIRED_TYPE; options?: never }
     | {
         rule: typeof REQUIRED_TYPOGRAPHY_PROPERTIES;
+
         options: RuleRequiredTypographyPropertiesOptions;
       }
     | { rule: typeof A11Y_MIN_CONTRAST; options: RuleA11yMinContrastOptions }
     | { rule: typeof A11Y_MIN_FONT_SIZE; options: RuleA11yMinFontSizeOptions }
     | { rule: typeof VALID_TYPOGRAPHY; options: RuleValidTypographyOptions }
   );
+
   want: { errors: string[]; success?: never } | { errors?: never; success: true };
 }
 
-describe('rules', () => {
+describe("rules", () => {
   const BASIC_TYPOGRAPHY = {
-    fontFamily: ['Helvetica'],
-    fontSize: { value: 1, unit: 'rem' },
+    fontFamily: ["Helvetica"],
+
+    fontSize: { value: 1, unit: "rem" },
+
     fontWeight: 400,
-    letterSpacing: { value: 0, unit: 'px' },
+
+    letterSpacing: { value: 0, unit: "px" },
+
     lineHeight: 1.25,
   };
 
   const tests: Test[] = [
     [
       `[${COLORSPACE}] srgb (success)`,
+
       {
         given: {
           rule: COLORSPACE,
-          options: { colorSpace: 'srgb' },
+
+          options: { colorSpace: "srgb" },
+
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: 'color',
+                  $type: "color",
+
                   $value: {
-                    colorSpace: 'srgb',
+                    colorSpace: "srgb",
+
                     components: [0.2255639098, 0.2255639098, 0.2518796992],
                   },
                 },
@@ -82,62 +96,81 @@ describe('rules', () => {
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${COLORSPACE}] oklab (success; ignored)`,
+
       {
         given: {
           rule: COLORSPACE,
-          options: { colorSpace: 'oklab', ignore: ['color.**'] },
+
+          options: { colorSpace: "oklab", ignore: ["color.**"] },
+
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: 'color',
-                  $value: { colorSpace: 'oklch', components: [0.8098, 0.089, 243.05] },
+                  $type: "color",
+
+                  $value: { colorSpace: "oklch", components: [0.8098, 0.089, 243.05] },
                 },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${COLORSPACE}] oklch (success)`,
+
       {
         given: {
           rule: COLORSPACE,
-          options: { colorSpace: 'oklch' },
+
+          options: { colorSpace: "oklch" },
+
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: 'color',
-                  $value: { colorSpace: 'oklch', components: [0.8098, 0.089, 243.05] },
+                  $type: "color",
+
+                  $value: { colorSpace: "oklch", components: [0.8098, 0.089, 243.05] },
                 },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${COLORSPACE}] oklch (fail)`,
+
       {
         given: {
           rule: COLORSPACE,
-          options: { colorSpace: 'oklch' },
+
+          options: { colorSpace: "oklch" },
+
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: 'color',
+                  $type: "color",
+
                   $value: {
-                    colorSpace: 'srgb',
+                    colorSpace: "srgb",
+
                     components: [0.2255639098, 0.2255639098, 0.2518796992],
                   },
                 },
@@ -145,487 +178,659 @@ describe('rules', () => {
             },
           },
         },
-        want: { errors: ['Color color.blue.100 not in colorspace oklch'] },
+
+        want: { errors: ["Color color.blue.100 not in colorspace oklch"] },
       },
     ],
+
     [
       `[${CONSISTENT_NAMING}] kebab-case (success)`,
+
       {
         given: {
           rule: CONSISTENT_NAMING,
-          options: { format: 'kebab-case' },
-          tokens: { token: { 'kebab-case': { $type: 'number', $value: 42 } } },
+
+          options: { format: "kebab-case" },
+
+          tokens: { token: { "kebab-case": { $type: "number", $value: 42 } } },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${CONSISTENT_NAMING}] kebab-case (fail)`,
+
       {
         given: {
           rule: CONSISTENT_NAMING,
-          options: { format: 'kebab-case' },
-          tokens: { token: { camelCase: { $type: 'number', $value: 42 } } },
+
+          options: { format: "kebab-case" },
+
+          tokens: { token: { camelCase: { $type: "number", $value: 42 } } },
         },
-        want: { errors: ['token.camelCase doesn’t match format kebab-case'] },
+
+        want: { errors: ["token.camelCase doesn’t match format kebab-case"] },
       },
     ],
+
     [
       `[${CONSISTENT_NAMING}] camelCase (success)`,
+
       {
         given: {
           rule: CONSISTENT_NAMING,
-          options: { format: 'camelCase' },
-          tokens: { token: { camelCase: { $type: 'number', $value: 42 } } },
+
+          options: { format: "camelCase" },
+
+          tokens: { token: { camelCase: { $type: "number", $value: 42 } } },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${CONSISTENT_NAMING}] camelCase (fail)`,
+
       {
         given: {
           rule: CONSISTENT_NAMING,
-          options: { format: 'camelCase' },
-          tokens: { token: { 'kebab-case': { $type: 'number', $value: 42 } } },
+
+          options: { format: "camelCase" },
+
+          tokens: { token: { "kebab-case": { $type: "number", $value: 42 } } },
         },
-        want: { errors: ['token.kebab-case doesn’t match format camelCase'] },
+
+        want: { errors: ["token.kebab-case doesn’t match format camelCase"] },
       },
     ],
+
     [
       `[${DESCRIPTIONS}] (success)`,
+
       {
         given: {
           rule: DESCRIPTIONS,
+
           options: {},
+
           tokens: {
-            number: { 42: { $type: 'number', $description: 'The number 42.', $value: 42 } },
+            number: { 42: { $type: "number", $description: "The number 42.", $value: 42 } },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${DESCRIPTIONS}] (success; ignored)`,
+
       {
         given: {
           rule: DESCRIPTIONS,
-          options: { ignore: ['number.**'] },
-          tokens: { number: { 42: { $type: 'number', $value: 42 } } },
+
+          options: { ignore: ["number.**"] },
+
+          tokens: { number: { 42: { $type: "number", $value: 42 } } },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${DESCRIPTIONS}] (fail)`,
+
       {
         given: {
           rule: DESCRIPTIONS,
+
           options: {},
-          tokens: { number: { 42: { $type: 'number', $value: 42 } } },
+
+          tokens: { number: { 42: { $type: "number", $value: 42 } } },
         },
-        want: { errors: ['number.42 missing description'] },
+
+        want: { errors: ["number.42 missing description"] },
       },
     ],
+
     [
       `[${DESCRIPTIONS}] (fail; group doesn’t count)`,
+
       {
         given: {
           rule: DESCRIPTIONS,
+
           options: {},
-          tokens: { number: { $description: 'Number group', 42: { $type: 'number', $value: 42 } } },
+
+          tokens: { number: { $description: "Number group", 42: { $type: "number", $value: 42 } } },
         },
-        want: { errors: ['number.42 missing description'] },
+
+        want: { errors: ["number.42 missing description"] },
       },
     ],
+
     [
       `[${DUPLICATE_VALUES}] no duplicates`,
+
       {
         given: {
           rule: DUPLICATE_VALUES,
+
           options: {},
+
           tokens: {
             color: {
               blue: {
-                '100': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.235, 0.235, 0.263] },
+                "100": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.235, 0.235, 0.263] },
                 },
-                '200': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.957, 0.98, 1] },
+
+                "200": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.957, 0.98, 1] },
                 },
-                '300': { $type: 'color', $value: '{color.blue.100}' },
+
+                "300": { $type: "color", $value: "{color.blue.100}" },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${DUPLICATE_VALUES}] duplicates (fail)`,
+
       {
         given: {
           rule: DUPLICATE_VALUES,
+
           options: {},
+
           tokens: {
             color: {
               blue: {
-                '100': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
+                "100": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
                 },
-                '200': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
+
+                "200": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
                 },
               },
             },
           },
         },
-        want: { errors: ['color.blue.200 declared a duplicate value'] },
+
+        want: { errors: ["color.blue.200 declared a duplicate value"] },
       },
     ],
+
     [
       `[${DUPLICATE_VALUES}] duplicate durations (fail)`,
+
       {
         given: {
           rule: DUPLICATE_VALUES,
+
           options: {},
+
           tokens: {
             duration: {
-              fast: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
-              quick: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
+              fast: { $type: "duration", $value: { value: 100, unit: "ms" } },
+
+              quick: { $type: "duration", $value: { value: 100, unit: "ms" } },
             },
           },
         },
-        want: { errors: ['duration.quick declared a duplicate value'] },
+
+        want: { errors: ["duration.quick declared a duplicate value"] },
       },
     ],
+
     [
       `[${DUPLICATE_VALUES}] aliased duration (success)`,
+
       {
         given: {
           rule: DUPLICATE_VALUES,
+
           options: {},
+
           tokens: {
             duration: {
-              fast: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
-              default: { $type: 'duration', $value: '{duration.fast}' },
+              fast: { $type: "duration", $value: { value: 100, unit: "ms" } },
+
+              default: { $type: "duration", $value: "{duration.fast}" },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${DUPLICATE_VALUES}] duplicates (success; ignored)`,
+
       {
         given: {
           rule: DUPLICATE_VALUES,
-          options: { ignore: ['color.**'] },
+
+          options: { ignore: ["color.**"] },
+
           tokens: {
             color: {
               blue: {
-                '100': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
+                "100": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
                 },
-                '200': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
+
+                "200": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
                 },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${DUPLICATE_VALUES}] custom tokens ignored`,
+
       {
         given: {
           rule: DUPLICATE_VALUES,
-          options: { ignore: ['color.**'] },
+
+          options: { ignore: ["color.**"] },
+
           tokens: {
             foo: {
               baz: {
-                bat: { $type: 'bar', $value: '123' },
-                boz: { $type: 'bar', $value: '456' },
+                bat: { $type: "bar", $value: "123" },
+
+                boz: { $type: "bar", $value: "456" },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${MAX_GAMUT}] srgb (success)`,
+
       {
         given: {
           rule: MAX_GAMUT,
-          options: { gamut: 'srgb' },
+
+          options: { gamut: "srgb" },
+
           tokens: {
             color: {
               yellow: {
-                $type: 'color',
-                $value: { colorSpace: 'oklch', components: [0.8794, 0.163, 96.35] },
+                $type: "color",
+
+                $value: { colorSpace: "oklch", components: [0.8794, 0.163, 96.35] },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${MAX_GAMUT}] srgb (fail)`,
+
       {
         given: {
           rule: MAX_GAMUT,
-          options: { gamut: 'srgb' },
+
+          options: { gamut: "srgb" },
+
           tokens: {
             color: {
               yellow: {
-                $type: 'color',
-                $value: { colorSpace: 'oklch', components: [0.8912, 0.2, 96.35] },
+                $type: "color",
+
+                $value: { colorSpace: "oklch", components: [0.8912, 0.2, 96.35] },
               },
             },
           },
         },
-        want: { errors: ['Color color.yellow is outside srgb gamut'] },
+
+        want: { errors: ["Color color.yellow is outside srgb gamut"] },
       },
     ],
+
     [
       `[${MAX_GAMUT}] p3 (success)`,
+
       {
         given: {
           rule: MAX_GAMUT,
-          options: { gamut: 'p3' },
+
+          options: { gamut: "p3" },
+
           tokens: {
             color: {
               yellow: {
-                $type: 'color',
-                $value: { colorSpace: 'oklch', components: [0.8912, 0.2, 96.35] },
+                $type: "color",
+
+                $value: { colorSpace: "oklch", components: [0.8912, 0.2, 96.35] },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${MAX_GAMUT}] p3 (fail)`,
+
       {
         given: {
           rule: MAX_GAMUT,
-          options: { gamut: 'p3' },
+
+          options: { gamut: "p3" },
+
           tokens: {
             color: {
               yellow: {
-                $type: 'color',
-                $value: { colorSpace: 'oklch', components: [0.8882, 0.217, 96.35] },
+                $type: "color",
+
+                $value: { colorSpace: "oklch", components: [0.8882, 0.217, 96.35] },
               },
             },
           },
         },
-        want: { errors: ['Color color.yellow is outside p3 gamut'] },
+
+        want: { errors: ["Color color.yellow is outside p3 gamut"] },
       },
     ],
+
     [
       `[${MAX_GAMUT}] rec2020 (success)`,
+
       {
         given: {
           rule: MAX_GAMUT,
-          options: { gamut: 'rec2020' },
+
+          options: { gamut: "rec2020" },
+
           tokens: {
             color: {
               yellow: {
-                $type: 'color',
-                $value: { colorSpace: 'oklch', components: [0.9059, 0.215, 96.35] },
+                $type: "color",
+
+                $value: { colorSpace: "oklch", components: [0.9059, 0.215, 96.35] },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${MAX_GAMUT}] rec2020 (fail)`,
+
       {
         given: {
           rule: MAX_GAMUT,
-          options: { gamut: 'rec2020' },
+
+          options: { gamut: "rec2020" },
+
           tokens: {
             color: {
               yellow: {
-                $type: 'color',
-                $value: { colorSpace: 'oklch', components: [0.9118, 0.234, 96.35] },
+                $type: "color",
+
+                $value: { colorSpace: "oklch", components: [0.9118, 0.234, 96.35] },
               },
             },
           },
         },
-        want: { errors: ['Color color.yellow is outside rec2020 gamut'] },
+
+        want: { errors: ["Color color.yellow is outside rec2020 gamut"] },
       },
     ],
+
     [
       `[${REQUIRED_CHILDREN}] tokens (success)`,
+
       {
         given: {
           rule: REQUIRED_CHILDREN,
-          options: { matches: [{ match: ['color.**'], requiredTokens: ['100', '200'] }] },
+
+          options: { matches: [{ match: ["color.**"], requiredTokens: ["100", "200"] }] },
+
           tokens: {
             color: {
               blue: {
-                '100': { $type: 'color', $value: '#3c3c43' },
-                '200': { $type: 'color', $value: '#f4faff' },
+                "100": { $type: "color", $value: "#3c3c43" },
+
+                "200": { $type: "color", $value: "#f4faff" },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${REQUIRED_CHILDREN}] tokens (failure)`,
+
       {
         given: {
           rule: REQUIRED_CHILDREN,
-          options: { matches: [{ match: ['color.**'], requiredTokens: ['100', '200'] }] },
+
+          options: { matches: [{ match: ["color.**"], requiredTokens: ["100", "200"] }] },
+
           tokens: {
             color: {
               blue: {
-                '100': {
-                  $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0.235, 0.235, 0.263] },
+                "100": {
+                  $type: "color",
+
+                  $value: { colorSpace: "srgb", components: [0.235, 0.235, 0.263] },
                 },
               },
             },
           },
         },
+
         want: { errors: ['Match 0: some groups missing required token "200"'] },
       },
     ],
+
     [
       `[${REQUIRED_CHILDREN}] groups (success)`,
+
       {
         given: {
           rule: REQUIRED_CHILDREN,
-          options: { matches: [{ match: ['color.**'], requiredGroups: ['action', 'error'] }] },
+
+          options: { matches: [{ match: ["color.**"], requiredGroups: ["action", "error"] }] },
+
           tokens: {
             color: {
               semantic: {
                 action: {
                   text: {
-                    $type: 'color',
-                    $value: { colorSpace: 'srgb', components: [0.369, 0.694, 0.937] },
+                    $type: "color",
+
+                    $value: { colorSpace: "srgb", components: [0.369, 0.694, 0.937] },
                   },
+
                   bg: {
-                    $type: 'color',
-                    $value: { colorSpace: 'srgb', components: [0.984, 0.992, 1] },
+                    $type: "color",
+
+                    $value: { colorSpace: "srgb", components: [0.984, 0.992, 1] },
                   },
                 },
+
                 error: {
                   text: {
-                    $type: 'color',
-                    $value: { colorSpace: 'srgb', components: [0.922, 0.557, 0.565] },
+                    $type: "color",
+
+                    $value: { colorSpace: "srgb", components: [0.922, 0.557, 0.565] },
                   },
+
                   bg: {
-                    $type: 'color',
-                    $value: { colorSpace: 'srgb', components: [1, 0.969, 0.969] },
+                    $type: "color",
+
+                    $value: { colorSpace: "srgb", components: [1, 0.969, 0.969] },
                   },
                 },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${REQUIRED_CHILDREN}] groups (failure)`,
+
       {
         given: {
           rule: REQUIRED_CHILDREN,
-          options: { matches: [{ match: ['color.**'], requiredGroups: ['action', 'error'] }] },
+
+          options: { matches: [{ match: ["color.**"], requiredGroups: ["action", "error"] }] },
+
           tokens: {
             color: {
               semantic: {
                 action: {
                   text: {
-                    $type: 'color',
-                    $value: { colorSpace: 'srgb', components: [0.369, 0.694, 0.937] },
+                    $type: "color",
+
+                    $value: { colorSpace: "srgb", components: [0.369, 0.694, 0.937] },
                   },
+
                   bg: {
-                    $type: 'color',
-                    $value: { colorSpace: 'srgb', components: [0.984, 0.992, 1] },
+                    $type: "color",
+
+                    $value: { colorSpace: "srgb", components: [0.984, 0.992, 1] },
                   },
                 },
               },
             },
           },
         },
+
         want: { errors: ['Match 0: some tokens missing required group "error"'] },
       },
     ],
+
     [
       `[${REQUIRED_MODES}] success`,
+
       {
         given: {
           rule: REQUIRED_MODES,
-          options: { matches: [{ match: ['typography.**'], modes: ['mobile', 'desktop'] }] },
+
+          options: { matches: [{ match: ["typography.**"], modes: ["mobile", "desktop"] }] },
+
           tokens: {
             typography: {
               size: {
                 body: {
-                  $type: 'dimension',
-                  $value: { value: 16, unit: 'px' },
-                  $extensions: { mode: { mobile: '16px', desktop: '16px' } },
+                  $type: "dimension",
+
+                  $value: { value: 16, unit: "px" },
+
+                  $extensions: { mode: { mobile: "16px", desktop: "16px" } },
                 },
               },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${REQUIRED_MODES}] fail`,
+
       {
         given: {
           rule: REQUIRED_MODES,
-          options: { matches: [{ match: ['typography.**'], modes: ['mobile', 'desktop'] }] },
+
+          options: { matches: [{ match: ["typography.**"], modes: ["mobile", "desktop"] }] },
+
           tokens: {
             typography: {
               size: {
                 body: {
-                  $type: 'dimension',
-                  $value: { value: 16, unit: 'px' },
-                  $extensions: { mode: { desktop: '16px' } },
+                  $type: "dimension",
+
+                  $value: { value: 16, unit: "px" },
+
+                  $extensions: { mode: { desktop: "16px" } },
                 },
               },
             },
           },
         },
+
         want: { errors: ['Token typography.size.body: missing required mode "mobile"'] },
       },
     ],
+
     [
       `[${REQUIRED_TYPOGRAPHY_PROPERTIES}] (deprecated)`,
+
       {
         given: {
           rule: REQUIRED_TYPOGRAPHY_PROPERTIES,
-          options: { properties: ['fontStyle'] },
+
+          options: { properties: ["fontStyle"] },
+
           tokens: {
             typography: {
               body: {
-                $type: 'typography',
+                $type: "typography",
+
                 $value: { ...BASIC_TYPOGRAPHY },
               },
             },
           },
         },
+
         want: {
           errors: [
             'This rule is deprecated. Use core/valid-typography. Missing required typographic property "fontStyle"',
@@ -633,245 +838,341 @@ describe('rules', () => {
         },
       },
     ],
+
     [
       `[${A11Y_MIN_CONTRAST}]: success (AA)`,
+
       {
         given: {
           rule: A11Y_MIN_CONTRAST,
-          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AA' },
+
+          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AA" },
+
           tokens: {
             color: {
-              $type: 'color',
-              fg: { $value: { colorSpace: 'srgb', components: [0, 0, 1] } },
-              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+              $type: "color",
+
+              fg: { $value: { colorSpace: "srgb", components: [0, 0, 1] } },
+
+              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${A11Y_MIN_CONTRAST}]: success (AAA)`,
+
       {
         given: {
           rule: A11Y_MIN_CONTRAST,
-          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AAA' },
+
+          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AAA" },
+
           tokens: {
             color: {
-              $type: 'color',
-              fg: { $value: { colorSpace: 'srgb', components: [0, 0, 1] } },
-              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+              $type: "color",
+
+              fg: { $value: { colorSpace: "srgb", components: [0, 0, 1] } },
+
+              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${A11Y_MIN_CONTRAST}]: fail (AA)`,
+
       {
         given: {
           rule: A11Y_MIN_CONTRAST,
-          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AA' },
+
+          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AA" },
+
           tokens: {
             color: {
-              $type: 'color',
-              fg: { $value: { colorSpace: 'srgb', components: [0.5, 0.5, 1] } },
-              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+              $type: "color",
+
+              fg: { $value: { colorSpace: "srgb", components: [0.5, 0.5, 1] } },
+
+              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
             },
           },
         },
-        want: { errors: ['Pair 1 failed; expected 4.5, got 3.27 (AA)'] },
+
+        want: { errors: ["Pair 1 failed; expected 4.5, got 3.27 (AA)"] },
       },
     ],
+
     [
       `[${A11Y_MIN_CONTRAST}]: pass (AA; large text)`,
+
       {
         given: {
           rule: A11Y_MIN_CONTRAST,
+
           options: {
-            pairs: [{ foreground: 'color.fg', background: 'color.bg', largeText: true }],
-            level: 'AA',
+            pairs: [{ foreground: "color.fg", background: "color.bg", largeText: true }],
+
+            level: "AA",
           },
+
           tokens: {
             color: {
-              $type: 'color',
-              fg: { $value: { colorSpace: 'srgb', components: [0.5, 0.5, 1] } },
-              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+              $type: "color",
+
+              fg: { $value: { colorSpace: "srgb", components: [0.5, 0.5, 1] } },
+
+              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${A11Y_MIN_CONTRAST}]: fail (AAA)`,
+
       {
         given: {
           rule: A11Y_MIN_CONTRAST,
-          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AAA' },
+
+          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AAA" },
+
           tokens: {
             color: {
-              $type: 'color',
-              fg: { $value: { colorSpace: 'srgb', components: [0.25, 0.25, 1] } },
-              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+              $type: "color",
+
+              fg: { $value: { colorSpace: "srgb", components: [0.25, 0.25, 1] } },
+
+              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
             },
           },
         },
-        want: { errors: ['Pair 1 failed; expected 7, got 6.2 (AAA)'] },
+
+        want: { errors: ["Pair 1 failed; expected 7, got 6.2 (AAA)"] },
       },
     ],
+
     [
       `[${A11Y_MIN_FONT_SIZE}]: success (px)`,
+
       {
         given: {
           rule: A11Y_MIN_FONT_SIZE,
+
           options: { minSizePx: 12 },
+
           tokens: {
             typography: {
-              $type: 'typography',
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'px', value: 12 } } },
-              rem: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'rem', value: 0.1 } } }, // ignored
+              $type: "typography",
+
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "px", value: 12 } } },
+
+              rem: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "rem", value: 0.1 } } }, // ignored
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${A11Y_MIN_FONT_SIZE}]: fail (px)`,
+
       {
         given: {
           rule: A11Y_MIN_FONT_SIZE,
+
           options: { minSizePx: 14 },
+
           tokens: {
             typography: {
-              $type: 'typography',
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'px', value: 12 } } },
+              $type: "typography",
+
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "px", value: 12 } } },
             },
           },
         },
-        want: { errors: ['typography.small font size too small. Expected minimum of 14px'] },
+
+        want: { errors: ["typography.small font size too small. Expected minimum of 14px"] },
       },
     ],
+
     [
       `[${A11Y_MIN_FONT_SIZE}]: success (rem)`,
+
       {
         given: {
           rule: A11Y_MIN_FONT_SIZE,
+
           options: { minSizeRem: 0.875 },
+
           tokens: {
             typography: {
-              $type: 'typography',
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'rem', value: 0.875 } } },
-              px: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'px', value: 2 } } }, // ignored
+              $type: "typography",
+
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "rem", value: 0.875 } } },
+
+              px: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "px", value: 2 } } }, // ignored
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${A11Y_MIN_FONT_SIZE}]: fail (rem)`,
+
       {
         given: {
           rule: A11Y_MIN_FONT_SIZE,
+
           options: { minSizeRem: 1 },
+
           tokens: {
             typography: {
-              $type: 'typography',
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'rem', value: 0.875 } } },
+              $type: "typography",
+
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "rem", value: 0.875 } } },
             },
           },
         },
-        want: { errors: ['typography.small font size too small. Expected minimum of 1rem'] },
+
+        want: { errors: ["typography.small font size too small. Expected minimum of 1rem"] },
       },
     ],
+
     [
       `[${REQUIRED_TYPE}]: fail`,
+
       {
         given: {
           rule: REQUIRED_TYPE,
+
           tokens: {
             color: {
-              $type: 'color',
-              blue: { 100: { $value: { colorSpace: 'srgb', components: [0, 0, 0.2] } } },
+              $type: "color",
+
+              blue: { 100: { $value: { colorSpace: "srgb", components: [0, 0, 0.2] } } },
             },
           },
         },
-        want: { errors: ['Token missing $type.'] },
+
+        want: { errors: ["Token missing $type."] },
       },
     ],
+
     [
       `[${VALID_TYPOGRAPHY}]: pass (non-spec property string)`,
+
       {
         given: {
           rule: VALID_TYPOGRAPHY,
+
           options: { requiredProperties: [] },
+
           tokens: {
             typography: {
-              $type: 'typography',
-              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: '14px' },
+              $type: "typography",
+
+              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: "14px" },
             },
           },
         },
+
         want: { success: true },
       },
     ],
+
     [
       `[${VALID_TYPOGRAPHY}]: pass (non-spec property dimension)`,
+
       {
         given: {
           rule: VALID_TYPOGRAPHY,
+
           options: { requiredProperties: [] },
+
           tokens: {
             typography: {
-              $type: 'typography',
-              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: { $value: 14, unit: 'px' } },
+              $type: "typography",
+
+              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: { $value: 14, unit: "px" } },
             },
           },
         },
+
         want: { success: true },
       },
     ],
   ];
 
-  test.each(tests)('%s', async (_, { given, want }) => {
+  test.each(tests)("%s", async (_, { given, want }) => {
     const errors: string[] = [];
+
     const config = defineConfig(
       {
         lint: {
           rules: {
-            [given.rule]: ['error', given.options],
+            [given.rule]: ["error", given.options],
           },
         },
       },
       { cwd },
     );
+
     const result = await parse([{ filename: DEFAULT_FILENAME, src: given.tokens }], {
       config,
+
       logger: {
-        level: 'error',
+        level: "error",
+
         debugCount: 0,
-        debugScope: '*',
+
+        debugScope: "*",
+
         errorCount: 0,
+
         infoCount: 0,
+
         warnCount: 0,
+
         error({ message }) {
           errors.push(message);
         },
+
         warn() {},
+
         info() {},
+
         debug() {},
+
         stats() {
           return { debugCount: 0, errorCount: 0, infoCount: 0, warnCount: 0 };
         },
+
         setLevel() {},
       } as Logger,
     });
-    const reported = errors.filter((error) => !error.includes('Lint failed with error'));
+
+    const reported = errors.filter((error) => !error.includes("Lint failed with error"));
+
     if (want.success) {
       expect(result).toBeTruthy();
+
       expect(reported).toEqual([]);
     } else {
       expect(reported).toEqual(want.errors);

--- a/packages/parser/test/lint.test.ts
+++ b/packages/parser/test/lint.test.ts
@@ -288,6 +288,38 @@ describe('rules', () => {
       },
     ],
     [
+      `[${DUPLICATE_VALUES}] duplicate durations (fail)`,
+      {
+        given: {
+          rule: DUPLICATE_VALUES,
+          options: {},
+          tokens: {
+            duration: {
+              fast: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
+              quick: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
+            },
+          },
+        },
+        want: { errors: ['duration.quick declared a duplicate value'] },
+      },
+    ],
+    [
+      `[${DUPLICATE_VALUES}] aliased duration (success)`,
+      {
+        given: {
+          rule: DUPLICATE_VALUES,
+          options: {},
+          tokens: {
+            duration: {
+              fast: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
+              default: { $type: 'duration', $value: '{duration.fast}' },
+            },
+          },
+        },
+        want: { success: true },
+      },
+    ],
+    [
       `[${DUPLICATE_VALUES}] duplicates (success; ignored)`,
       {
         given: {
@@ -837,12 +869,14 @@ describe('rules', () => {
         setLevel() {},
       } as Logger,
     });
+    const reported = errors.filter((error) => !error.includes('Lint failed with error'));
     if (want.success) {
       expect(result).toBeTruthy();
+      // A truthy result on its own says nothing about what the rule reported, so a
+      // success fixture used to pass while the rule under test raised errors.
+      expect(reported).toEqual([]);
     } else {
-      expect(errors.filter((error) => !error.includes('Lint failed with error'))).toEqual(
-        want.errors,
-      );
+      expect(reported).toEqual(want.errors);
     }
   });
 });

--- a/packages/parser/test/lint.test.ts
+++ b/packages/parser/test/lint.test.ts
@@ -872,8 +872,6 @@ describe('rules', () => {
     const reported = errors.filter((error) => !error.includes('Lint failed with error'));
     if (want.success) {
       expect(result).toBeTruthy();
-      // A truthy result on its own says nothing about what the rule reported, so a
-      // success fixture used to pass while the rule under test raised errors.
       expect(reported).toEqual([]);
     } else {
       expect(reported).toEqual(want.errors);

--- a/packages/parser/test/lint.test.ts
+++ b/packages/parser/test/lint.test.ts
@@ -29,7 +29,6 @@ import {
 
 const cwd = new URL(import.meta.url);
 const DEFAULT_FILENAME = new URL('file:///tokens.json');
-
 type Test = [string, TestOptions];
 
 interface TestOptions {

--- a/packages/parser/test/lint.test.ts
+++ b/packages/parser/test/lint.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from 'vitest';
 
-import { defineConfig, type Logger, parse } from "../src/index.js";
-
+import { defineConfig, type Logger, parse } from '../src/index.js';
 import {
   A11Y_MIN_CONTRAST,
   A11Y_MIN_FONT_SIZE,
@@ -26,11 +25,10 @@ import {
   type RuleRequiredTypographyPropertiesOptions,
   type RuleValidTypographyOptions,
   VALID_TYPOGRAPHY,
-} from "../src/lint/plugin-core/index.js";
+} from '../src/lint/plugin-core/index.js';
 
 const cwd = new URL(import.meta.url);
-
-const DEFAULT_FILENAME = new URL("file:///tokens.json");
+const DEFAULT_FILENAME = new URL('file:///tokens.json');
 
 type Test = [string, TestOptions];
 

--- a/packages/parser/test/lint.test.ts
+++ b/packages/parser/test/lint.test.ts
@@ -54,15 +54,15 @@ interface TestOptions {
   want: { errors: string[]; success?: never } | { errors?: never; success: true };
 }
 
-describe("rules", () => {
+describe('rules', () => {
   const BASIC_TYPOGRAPHY = {
-    fontFamily: ["Helvetica"],
+    fontFamily: ['Helvetica'],
 
-    fontSize: { value: 1, unit: "rem" },
+    fontSize: { value: 1, unit: 'rem' },
 
     fontWeight: 400,
 
-    letterSpacing: { value: 0, unit: "px" },
+    letterSpacing: { value: 0, unit: 'px' },
 
     lineHeight: 1.25,
   };
@@ -75,16 +75,16 @@ describe("rules", () => {
         given: {
           rule: COLORSPACE,
 
-          options: { colorSpace: "srgb" },
+          options: { colorSpace: 'srgb' },
 
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: "color",
+                  $type: 'color',
 
                   $value: {
-                    colorSpace: "srgb",
+                    colorSpace: 'srgb',
 
                     components: [0.2255639098, 0.2255639098, 0.2518796992],
                   },
@@ -105,15 +105,15 @@ describe("rules", () => {
         given: {
           rule: COLORSPACE,
 
-          options: { colorSpace: "oklab", ignore: ["color.**"] },
+          options: { colorSpace: 'oklab', ignore: ['color.**'] },
 
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: "color",
+                  $type: 'color',
 
-                  $value: { colorSpace: "oklch", components: [0.8098, 0.089, 243.05] },
+                  $value: { colorSpace: 'oklch', components: [0.8098, 0.089, 243.05] },
                 },
               },
             },
@@ -131,15 +131,15 @@ describe("rules", () => {
         given: {
           rule: COLORSPACE,
 
-          options: { colorSpace: "oklch" },
+          options: { colorSpace: 'oklch' },
 
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: "color",
+                  $type: 'color',
 
-                  $value: { colorSpace: "oklch", components: [0.8098, 0.089, 243.05] },
+                  $value: { colorSpace: 'oklch', components: [0.8098, 0.089, 243.05] },
                 },
               },
             },
@@ -157,16 +157,16 @@ describe("rules", () => {
         given: {
           rule: COLORSPACE,
 
-          options: { colorSpace: "oklch" },
+          options: { colorSpace: 'oklch' },
 
           tokens: {
             color: {
               blue: {
                 100: {
-                  $type: "color",
+                  $type: 'color',
 
                   $value: {
-                    colorSpace: "srgb",
+                    colorSpace: 'srgb',
 
                     components: [0.2255639098, 0.2255639098, 0.2518796992],
                   },
@@ -176,7 +176,7 @@ describe("rules", () => {
           },
         },
 
-        want: { errors: ["Color color.blue.100 not in colorspace oklch"] },
+        want: { errors: ['Color color.blue.100 not in colorspace oklch'] },
       },
     ],
 
@@ -187,9 +187,9 @@ describe("rules", () => {
         given: {
           rule: CONSISTENT_NAMING,
 
-          options: { format: "kebab-case" },
+          options: { format: 'kebab-case' },
 
-          tokens: { token: { "kebab-case": { $type: "number", $value: 42 } } },
+          tokens: { token: { 'kebab-case': { $type: 'number', $value: 42 } } },
         },
 
         want: { success: true },
@@ -203,12 +203,12 @@ describe("rules", () => {
         given: {
           rule: CONSISTENT_NAMING,
 
-          options: { format: "kebab-case" },
+          options: { format: 'kebab-case' },
 
-          tokens: { token: { camelCase: { $type: "number", $value: 42 } } },
+          tokens: { token: { camelCase: { $type: 'number', $value: 42 } } },
         },
 
-        want: { errors: ["token.camelCase doesn’t match format kebab-case"] },
+        want: { errors: ['token.camelCase doesn’t match format kebab-case'] },
       },
     ],
 
@@ -219,9 +219,9 @@ describe("rules", () => {
         given: {
           rule: CONSISTENT_NAMING,
 
-          options: { format: "camelCase" },
+          options: { format: 'camelCase' },
 
-          tokens: { token: { camelCase: { $type: "number", $value: 42 } } },
+          tokens: { token: { camelCase: { $type: 'number', $value: 42 } } },
         },
 
         want: { success: true },
@@ -235,12 +235,12 @@ describe("rules", () => {
         given: {
           rule: CONSISTENT_NAMING,
 
-          options: { format: "camelCase" },
+          options: { format: 'camelCase' },
 
-          tokens: { token: { "kebab-case": { $type: "number", $value: 42 } } },
+          tokens: { token: { 'kebab-case': { $type: 'number', $value: 42 } } },
         },
 
-        want: { errors: ["token.kebab-case doesn’t match format camelCase"] },
+        want: { errors: ['token.kebab-case doesn’t match format camelCase'] },
       },
     ],
 
@@ -254,7 +254,7 @@ describe("rules", () => {
           options: {},
 
           tokens: {
-            number: { 42: { $type: "number", $description: "The number 42.", $value: 42 } },
+            number: { 42: { $type: 'number', $description: 'The number 42.', $value: 42 } },
           },
         },
 
@@ -269,9 +269,9 @@ describe("rules", () => {
         given: {
           rule: DESCRIPTIONS,
 
-          options: { ignore: ["number.**"] },
+          options: { ignore: ['number.**'] },
 
-          tokens: { number: { 42: { $type: "number", $value: 42 } } },
+          tokens: { number: { 42: { $type: 'number', $value: 42 } } },
         },
 
         want: { success: true },
@@ -287,10 +287,10 @@ describe("rules", () => {
 
           options: {},
 
-          tokens: { number: { 42: { $type: "number", $value: 42 } } },
+          tokens: { number: { 42: { $type: 'number', $value: 42 } } },
         },
 
-        want: { errors: ["number.42 missing description"] },
+        want: { errors: ['number.42 missing description'] },
       },
     ],
 
@@ -303,10 +303,10 @@ describe("rules", () => {
 
           options: {},
 
-          tokens: { number: { $description: "Number group", 42: { $type: "number", $value: 42 } } },
+          tokens: { number: { $description: 'Number group', 42: { $type: 'number', $value: 42 } } },
         },
 
-        want: { errors: ["number.42 missing description"] },
+        want: { errors: ['number.42 missing description'] },
       },
     ],
 
@@ -322,19 +322,19 @@ describe("rules", () => {
           tokens: {
             color: {
               blue: {
-                "100": {
-                  $type: "color",
+                '100': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.235, 0.235, 0.263] },
+                  $value: { colorSpace: 'srgb', components: [0.235, 0.235, 0.263] },
                 },
 
-                "200": {
-                  $type: "color",
+                '200': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.957, 0.98, 1] },
+                  $value: { colorSpace: 'srgb', components: [0.957, 0.98, 1] },
                 },
 
-                "300": { $type: "color", $value: "{color.blue.100}" },
+                '300': { $type: 'color', $value: '{color.blue.100}' },
               },
             },
           },
@@ -356,23 +356,23 @@ describe("rules", () => {
           tokens: {
             color: {
               blue: {
-                "100": {
-                  $type: "color",
+                '100': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
+                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
                 },
 
-                "200": {
-                  $type: "color",
+                '200': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
+                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
                 },
               },
             },
           },
         },
 
-        want: { errors: ["color.blue.200 declared a duplicate value"] },
+        want: { errors: ['color.blue.200 declared a duplicate value'] },
       },
     ],
 
@@ -387,14 +387,14 @@ describe("rules", () => {
 
           tokens: {
             duration: {
-              fast: { $type: "duration", $value: { value: 100, unit: "ms" } },
+              fast: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
 
-              quick: { $type: "duration", $value: { value: 100, unit: "ms" } },
+              quick: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
             },
           },
         },
 
-        want: { errors: ["duration.quick declared a duplicate value"] },
+        want: { errors: ['duration.quick declared a duplicate value'] },
       },
     ],
 
@@ -409,9 +409,9 @@ describe("rules", () => {
 
           tokens: {
             duration: {
-              fast: { $type: "duration", $value: { value: 100, unit: "ms" } },
+              fast: { $type: 'duration', $value: { value: 100, unit: 'ms' } },
 
-              default: { $type: "duration", $value: "{duration.fast}" },
+              default: { $type: 'duration', $value: '{duration.fast}' },
             },
           },
         },
@@ -427,21 +427,21 @@ describe("rules", () => {
         given: {
           rule: DUPLICATE_VALUES,
 
-          options: { ignore: ["color.**"] },
+          options: { ignore: ['color.**'] },
 
           tokens: {
             color: {
               blue: {
-                "100": {
-                  $type: "color",
+                '100': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
+                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
                 },
 
-                "200": {
-                  $type: "color",
+                '200': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.24, 0.24, 0.26] },
+                  $value: { colorSpace: 'srgb', components: [0.24, 0.24, 0.26] },
                 },
               },
             },
@@ -459,14 +459,14 @@ describe("rules", () => {
         given: {
           rule: DUPLICATE_VALUES,
 
-          options: { ignore: ["color.**"] },
+          options: { ignore: ['color.**'] },
 
           tokens: {
             foo: {
               baz: {
-                bat: { $type: "bar", $value: "123" },
+                bat: { $type: 'bar', $value: '123' },
 
-                boz: { $type: "bar", $value: "456" },
+                boz: { $type: 'bar', $value: '456' },
               },
             },
           },
@@ -483,14 +483,14 @@ describe("rules", () => {
         given: {
           rule: MAX_GAMUT,
 
-          options: { gamut: "srgb" },
+          options: { gamut: 'srgb' },
 
           tokens: {
             color: {
               yellow: {
-                $type: "color",
+                $type: 'color',
 
-                $value: { colorSpace: "oklch", components: [0.8794, 0.163, 96.35] },
+                $value: { colorSpace: 'oklch', components: [0.8794, 0.163, 96.35] },
               },
             },
           },
@@ -507,20 +507,20 @@ describe("rules", () => {
         given: {
           rule: MAX_GAMUT,
 
-          options: { gamut: "srgb" },
+          options: { gamut: 'srgb' },
 
           tokens: {
             color: {
               yellow: {
-                $type: "color",
+                $type: 'color',
 
-                $value: { colorSpace: "oklch", components: [0.8912, 0.2, 96.35] },
+                $value: { colorSpace: 'oklch', components: [0.8912, 0.2, 96.35] },
               },
             },
           },
         },
 
-        want: { errors: ["Color color.yellow is outside srgb gamut"] },
+        want: { errors: ['Color color.yellow is outside srgb gamut'] },
       },
     ],
 
@@ -531,14 +531,14 @@ describe("rules", () => {
         given: {
           rule: MAX_GAMUT,
 
-          options: { gamut: "p3" },
+          options: { gamut: 'p3' },
 
           tokens: {
             color: {
               yellow: {
-                $type: "color",
+                $type: 'color',
 
-                $value: { colorSpace: "oklch", components: [0.8912, 0.2, 96.35] },
+                $value: { colorSpace: 'oklch', components: [0.8912, 0.2, 96.35] },
               },
             },
           },
@@ -555,20 +555,20 @@ describe("rules", () => {
         given: {
           rule: MAX_GAMUT,
 
-          options: { gamut: "p3" },
+          options: { gamut: 'p3' },
 
           tokens: {
             color: {
               yellow: {
-                $type: "color",
+                $type: 'color',
 
-                $value: { colorSpace: "oklch", components: [0.8882, 0.217, 96.35] },
+                $value: { colorSpace: 'oklch', components: [0.8882, 0.217, 96.35] },
               },
             },
           },
         },
 
-        want: { errors: ["Color color.yellow is outside p3 gamut"] },
+        want: { errors: ['Color color.yellow is outside p3 gamut'] },
       },
     ],
 
@@ -579,14 +579,14 @@ describe("rules", () => {
         given: {
           rule: MAX_GAMUT,
 
-          options: { gamut: "rec2020" },
+          options: { gamut: 'rec2020' },
 
           tokens: {
             color: {
               yellow: {
-                $type: "color",
+                $type: 'color',
 
-                $value: { colorSpace: "oklch", components: [0.9059, 0.215, 96.35] },
+                $value: { colorSpace: 'oklch', components: [0.9059, 0.215, 96.35] },
               },
             },
           },
@@ -603,20 +603,20 @@ describe("rules", () => {
         given: {
           rule: MAX_GAMUT,
 
-          options: { gamut: "rec2020" },
+          options: { gamut: 'rec2020' },
 
           tokens: {
             color: {
               yellow: {
-                $type: "color",
+                $type: 'color',
 
-                $value: { colorSpace: "oklch", components: [0.9118, 0.234, 96.35] },
+                $value: { colorSpace: 'oklch', components: [0.9118, 0.234, 96.35] },
               },
             },
           },
         },
 
-        want: { errors: ["Color color.yellow is outside rec2020 gamut"] },
+        want: { errors: ['Color color.yellow is outside rec2020 gamut'] },
       },
     ],
 
@@ -627,14 +627,14 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_CHILDREN,
 
-          options: { matches: [{ match: ["color.**"], requiredTokens: ["100", "200"] }] },
+          options: { matches: [{ match: ['color.**'], requiredTokens: ['100', '200'] }] },
 
           tokens: {
             color: {
               blue: {
-                "100": { $type: "color", $value: "#3c3c43" },
+                '100': { $type: 'color', $value: '#3c3c43' },
 
-                "200": { $type: "color", $value: "#f4faff" },
+                '200': { $type: 'color', $value: '#f4faff' },
               },
             },
           },
@@ -651,15 +651,15 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_CHILDREN,
 
-          options: { matches: [{ match: ["color.**"], requiredTokens: ["100", "200"] }] },
+          options: { matches: [{ match: ['color.**'], requiredTokens: ['100', '200'] }] },
 
           tokens: {
             color: {
               blue: {
-                "100": {
-                  $type: "color",
+                '100': {
+                  $type: 'color',
 
-                  $value: { colorSpace: "srgb", components: [0.235, 0.235, 0.263] },
+                  $value: { colorSpace: 'srgb', components: [0.235, 0.235, 0.263] },
                 },
               },
             },
@@ -677,36 +677,36 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_CHILDREN,
 
-          options: { matches: [{ match: ["color.**"], requiredGroups: ["action", "error"] }] },
+          options: { matches: [{ match: ['color.**'], requiredGroups: ['action', 'error'] }] },
 
           tokens: {
             color: {
               semantic: {
                 action: {
                   text: {
-                    $type: "color",
+                    $type: 'color',
 
-                    $value: { colorSpace: "srgb", components: [0.369, 0.694, 0.937] },
+                    $value: { colorSpace: 'srgb', components: [0.369, 0.694, 0.937] },
                   },
 
                   bg: {
-                    $type: "color",
+                    $type: 'color',
 
-                    $value: { colorSpace: "srgb", components: [0.984, 0.992, 1] },
+                    $value: { colorSpace: 'srgb', components: [0.984, 0.992, 1] },
                   },
                 },
 
                 error: {
                   text: {
-                    $type: "color",
+                    $type: 'color',
 
-                    $value: { colorSpace: "srgb", components: [0.922, 0.557, 0.565] },
+                    $value: { colorSpace: 'srgb', components: [0.922, 0.557, 0.565] },
                   },
 
                   bg: {
-                    $type: "color",
+                    $type: 'color',
 
-                    $value: { colorSpace: "srgb", components: [1, 0.969, 0.969] },
+                    $value: { colorSpace: 'srgb', components: [1, 0.969, 0.969] },
                   },
                 },
               },
@@ -725,22 +725,22 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_CHILDREN,
 
-          options: { matches: [{ match: ["color.**"], requiredGroups: ["action", "error"] }] },
+          options: { matches: [{ match: ['color.**'], requiredGroups: ['action', 'error'] }] },
 
           tokens: {
             color: {
               semantic: {
                 action: {
                   text: {
-                    $type: "color",
+                    $type: 'color',
 
-                    $value: { colorSpace: "srgb", components: [0.369, 0.694, 0.937] },
+                    $value: { colorSpace: 'srgb', components: [0.369, 0.694, 0.937] },
                   },
 
                   bg: {
-                    $type: "color",
+                    $type: 'color',
 
-                    $value: { colorSpace: "srgb", components: [0.984, 0.992, 1] },
+                    $value: { colorSpace: 'srgb', components: [0.984, 0.992, 1] },
                   },
                 },
               },
@@ -759,17 +759,17 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_MODES,
 
-          options: { matches: [{ match: ["typography.**"], modes: ["mobile", "desktop"] }] },
+          options: { matches: [{ match: ['typography.**'], modes: ['mobile', 'desktop'] }] },
 
           tokens: {
             typography: {
               size: {
                 body: {
-                  $type: "dimension",
+                  $type: 'dimension',
 
-                  $value: { value: 16, unit: "px" },
+                  $value: { value: 16, unit: 'px' },
 
-                  $extensions: { mode: { mobile: "16px", desktop: "16px" } },
+                  $extensions: { mode: { mobile: '16px', desktop: '16px' } },
                 },
               },
             },
@@ -787,17 +787,17 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_MODES,
 
-          options: { matches: [{ match: ["typography.**"], modes: ["mobile", "desktop"] }] },
+          options: { matches: [{ match: ['typography.**'], modes: ['mobile', 'desktop'] }] },
 
           tokens: {
             typography: {
               size: {
                 body: {
-                  $type: "dimension",
+                  $type: 'dimension',
 
-                  $value: { value: 16, unit: "px" },
+                  $value: { value: 16, unit: 'px' },
 
-                  $extensions: { mode: { desktop: "16px" } },
+                  $extensions: { mode: { desktop: '16px' } },
                 },
               },
             },
@@ -815,12 +815,12 @@ describe("rules", () => {
         given: {
           rule: REQUIRED_TYPOGRAPHY_PROPERTIES,
 
-          options: { properties: ["fontStyle"] },
+          options: { properties: ['fontStyle'] },
 
           tokens: {
             typography: {
               body: {
-                $type: "typography",
+                $type: 'typography',
 
                 $value: { ...BASIC_TYPOGRAPHY },
               },
@@ -843,15 +843,15 @@ describe("rules", () => {
         given: {
           rule: A11Y_MIN_CONTRAST,
 
-          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AA" },
+          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AA' },
 
           tokens: {
             color: {
-              $type: "color",
+              $type: 'color',
 
-              fg: { $value: { colorSpace: "srgb", components: [0, 0, 1] } },
+              fg: { $value: { colorSpace: 'srgb', components: [0, 0, 1] } },
 
-              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
+              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
             },
           },
         },
@@ -867,15 +867,15 @@ describe("rules", () => {
         given: {
           rule: A11Y_MIN_CONTRAST,
 
-          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AAA" },
+          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AAA' },
 
           tokens: {
             color: {
-              $type: "color",
+              $type: 'color',
 
-              fg: { $value: { colorSpace: "srgb", components: [0, 0, 1] } },
+              fg: { $value: { colorSpace: 'srgb', components: [0, 0, 1] } },
 
-              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
+              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
             },
           },
         },
@@ -891,20 +891,20 @@ describe("rules", () => {
         given: {
           rule: A11Y_MIN_CONTRAST,
 
-          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AA" },
+          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AA' },
 
           tokens: {
             color: {
-              $type: "color",
+              $type: 'color',
 
-              fg: { $value: { colorSpace: "srgb", components: [0.5, 0.5, 1] } },
+              fg: { $value: { colorSpace: 'srgb', components: [0.5, 0.5, 1] } },
 
-              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
+              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
             },
           },
         },
 
-        want: { errors: ["Pair 1 failed; expected 4.5, got 3.27 (AA)"] },
+        want: { errors: ['Pair 1 failed; expected 4.5, got 3.27 (AA)'] },
       },
     ],
 
@@ -916,18 +916,18 @@ describe("rules", () => {
           rule: A11Y_MIN_CONTRAST,
 
           options: {
-            pairs: [{ foreground: "color.fg", background: "color.bg", largeText: true }],
+            pairs: [{ foreground: 'color.fg', background: 'color.bg', largeText: true }],
 
-            level: "AA",
+            level: 'AA',
           },
 
           tokens: {
             color: {
-              $type: "color",
+              $type: 'color',
 
-              fg: { $value: { colorSpace: "srgb", components: [0.5, 0.5, 1] } },
+              fg: { $value: { colorSpace: 'srgb', components: [0.5, 0.5, 1] } },
 
-              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
+              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
             },
           },
         },
@@ -943,20 +943,20 @@ describe("rules", () => {
         given: {
           rule: A11Y_MIN_CONTRAST,
 
-          options: { pairs: [{ foreground: "color.fg", background: "color.bg" }], level: "AAA" },
+          options: { pairs: [{ foreground: 'color.fg', background: 'color.bg' }], level: 'AAA' },
 
           tokens: {
             color: {
-              $type: "color",
+              $type: 'color',
 
-              fg: { $value: { colorSpace: "srgb", components: [0.25, 0.25, 1] } },
+              fg: { $value: { colorSpace: 'srgb', components: [0.25, 0.25, 1] } },
 
-              bg: { $value: { colorSpace: "srgb", components: [1, 1, 1] } },
+              bg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
             },
           },
         },
 
-        want: { errors: ["Pair 1 failed; expected 7, got 6.2 (AAA)"] },
+        want: { errors: ['Pair 1 failed; expected 7, got 6.2 (AAA)'] },
       },
     ],
 
@@ -971,11 +971,11 @@ describe("rules", () => {
 
           tokens: {
             typography: {
-              $type: "typography",
+              $type: 'typography',
 
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "px", value: 12 } } },
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'px', value: 12 } } },
 
-              rem: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "rem", value: 0.1 } } }, // ignored
+              rem: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'rem', value: 0.1 } } }, // ignored
             },
           },
         },
@@ -995,14 +995,14 @@ describe("rules", () => {
 
           tokens: {
             typography: {
-              $type: "typography",
+              $type: 'typography',
 
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "px", value: 12 } } },
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'px', value: 12 } } },
             },
           },
         },
 
-        want: { errors: ["typography.small font size too small. Expected minimum of 14px"] },
+        want: { errors: ['typography.small font size too small. Expected minimum of 14px'] },
       },
     ],
 
@@ -1017,11 +1017,11 @@ describe("rules", () => {
 
           tokens: {
             typography: {
-              $type: "typography",
+              $type: 'typography',
 
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "rem", value: 0.875 } } },
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'rem', value: 0.875 } } },
 
-              px: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "px", value: 2 } } }, // ignored
+              px: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'px', value: 2 } } }, // ignored
             },
           },
         },
@@ -1041,14 +1041,14 @@ describe("rules", () => {
 
           tokens: {
             typography: {
-              $type: "typography",
+              $type: 'typography',
 
-              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: "rem", value: 0.875 } } },
+              small: { $value: { ...BASIC_TYPOGRAPHY, fontSize: { unit: 'rem', value: 0.875 } } },
             },
           },
         },
 
-        want: { errors: ["typography.small font size too small. Expected minimum of 1rem"] },
+        want: { errors: ['typography.small font size too small. Expected minimum of 1rem'] },
       },
     ],
 
@@ -1061,14 +1061,14 @@ describe("rules", () => {
 
           tokens: {
             color: {
-              $type: "color",
+              $type: 'color',
 
-              blue: { 100: { $value: { colorSpace: "srgb", components: [0, 0, 0.2] } } },
+              blue: { 100: { $value: { colorSpace: 'srgb', components: [0, 0, 0.2] } } },
             },
           },
         },
 
-        want: { errors: ["Token missing $type."] },
+        want: { errors: ['Token missing $type.'] },
       },
     ],
 
@@ -1083,9 +1083,9 @@ describe("rules", () => {
 
           tokens: {
             typography: {
-              $type: "typography",
+              $type: 'typography',
 
-              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: "14px" },
+              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: '14px' },
             },
           },
         },
@@ -1105,9 +1105,9 @@ describe("rules", () => {
 
           tokens: {
             typography: {
-              $type: "typography",
+              $type: 'typography',
 
-              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: { $value: 14, unit: "px" } },
+              $value: { ...BASIC_TYPOGRAPHY, paragraphSpacing: { $value: 14, unit: 'px' } },
             },
           },
         },
@@ -1117,14 +1117,14 @@ describe("rules", () => {
     ],
   ];
 
-  test.each(tests)("%s", async (_, { given, want }) => {
+  test.each(tests)('%s', async (_, { given, want }) => {
     const errors: string[] = [];
 
     const config = defineConfig(
       {
         lint: {
           rules: {
-            [given.rule]: ["error", given.options],
+            [given.rule]: ['error', given.options],
           },
         },
       },
@@ -1135,11 +1135,11 @@ describe("rules", () => {
       config,
 
       logger: {
-        level: "error",
+        level: 'error',
 
         debugCount: 0,
 
-        debugScope: "*",
+        debugScope: '*',
 
         errorCount: 0,
 
@@ -1165,7 +1165,7 @@ describe("rules", () => {
       } as Logger,
     });
 
-    const reported = errors.filter((error) => !error.includes("Lint failed with error"));
+    const reported = errors.filter((error) => !error.includes('Lint failed with error'));
 
     if (want.success) {
       expect(result).toBeTruthy();


### PR DESCRIPTION
Fixes items 1 and 2 of #804.

### `core/duplicate-values` no longer reports aliases

The guard was `typeof t.aliasOf === 'string' && isAlias(t.aliasOf)`. `aliasOf` holds a resolved token ID — `refToTokenID()` at `parse/token.ts:290` returns `color.blue.100` — while `isAlias()` matches the `{color.blue.100}` reference form, so the second half was never true and every alias was compared against the token it points at.

It was also in the wrong place. Only the primitive branch consulted it; colors, dimensions, shadows and the rest go through the structural comparison below, which had no alias check at all. Because tokens are visited in sorted-ID order, the report then named whichever of the two sorted first, so an alias could get the original blamed for it. Hoisting the check above the split covers both paths with one guard, which also matches the rule's stated behaviour ("excludes aliases").

### `duration` now goes through the structural comparison

It was in the primitive list and so compared with `Set.has()`, but a normalized duration value is the object `{ value, unit }` — identity comparison, never a match, so duplicate durations were never reported. Removing it from the list sends it down the same path as `dimension`, which was already excluded for exactly this reason.

### The runner change is what makes the fixture prove anything

`[core/duplicate-values] no duplicates` is the alias case, and it was already emitting `color.blue.300 declared a duplicate value` while passing, because the success branch asserted only `expect(result).toBeTruthy()` and never looked at the collected errors. That branch now checks them.

I measured the blast radius before changing it: tightening the assertion fails **exactly one** fixture on current `main` — this one. The other 23 `success: true` cases are genuinely clean, so this is not a change that papers over anything else.

With the assertion in place, reverting the rule alone fails three fixtures:

```
FAIL  test/lint.test.ts > rules > [core/duplicate-values] no duplicates
FAIL  test/lint.test.ts > rules > [core/duplicate-values] duplicate durations (fail)
FAIL  test/lint.test.ts > rules > [core/duplicate-values] aliased duration (success)
      Tests  3 failed | 40 passed (43)
```

and with it, `43 passed (43)`.

### Checks

`corepack pnpm --filter @terrazzo/parser test` → `25 passed (25)` files, `268 passed | 1 skipped`. `oxlint --quiet` clean, `tsc --noEmit` clean. Changeset included.

### Possible drawbacks

The two added fixtures cover a duplicate duration and an aliased duration; I have not gone through the other object-valued types one by one to check that each behaves as expected now that the alias guard applies to them — the guard only ever skips, so it cannot introduce a false report, but it does mean an aliased token of any type is no longer compared at all, which is the intended reading of "excludes aliases" and a behaviour change for anyone relying on the old output.

Items 3, 4 and 5 of #804 are untouched here. Item 4 in particular is a polarity change that would break anyone who wrote a validator against the current behaviour, and it seemed better to leave that decision with you than to bundle it in.
