### PR TITLE
Remove unused fast-deep-equal dependency from @terrazzo/parser

### DIFF
--- a/.changeset/lazy-crabs-search.md
+++ b/.changeset/lazy-crabs-search.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/parser": patch
+---
+
+Remove the unused `fast-deep-equal` dependency. Nothing in the package imported it, so it was installed by every consumer of `@terrazzo/parser` (and by extension `@terrazzo/cli`) without ever being loaded.

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -48,7 +48,6 @@
     "@terrazzo/token-types": "workspace:^",
     "@types/babel__code-frame": "^7.27.0",
     "colorjs.io": "catalog:",
-    "fast-deep-equal": "^3.1.3",
     "merge-anything": "^5.1.7",
     "picocolors": "^1.1.1",
     "scule": "^1.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,9 +254,6 @@ importers:
       colorjs.io:
         specifier: 'catalog:'
         version: 0.6.1
-      fast-deep-equal:
-        specifier: ^3.1.3
-        version: 3.1.3
       merge-anything:
         specifier: ^5.1.7
         version: 5.1.7


### PR DESCRIPTION
Closes #809.

Removes `fast-deep-equal` from `@terrazzo/parser`'s `dependencies`. Nothing in the package imports it, so it was being installed by every consumer of the parser — and by extension of `@terrazzo/cli` — without ever being loaded.

I took the removal option rather than the other one you mentioned in the issue. Wiring `fast-deep-equal` into `duplicate-values.ts` would change which tokens the rule reports as duplicates, since `JSON.stringify` is key-order sensitive and a real deep equal is not, and that felt like your call to make rather than something to slip into a dependency cleanup.

## What changed

Three files: the `dependencies` entry, the matching `pnpm-lock.yaml` importer block, and a `patch` changeset. `pnpm install` produced the lockfile change on its own and touched nothing else.

`fast-deep-equal@3.1.3` stays in `pnpm-lock.yaml` further down, because `ajv` and `eslint` still pull it into the dev tree. It leaves the published tree only.

## Verification

Re-run at `1bedd87`, on Node 22.23.2 and pnpm 11.17.0, with a baseline captured on the unmodified checkout first.

Nothing imports it, checked for renamed and aliased forms too:

```
$ git grep -E "(from|require\(|import\()\s*['\"]fast-deep-equal"
(no matches)
```

`git grep fast-deep-equal` matches only `packages/parser/package.json:51` and seven lines of `pnpm-lock.yaml` — the parser's importer entry, the package definition itself, and the `ajv@6`, `ajv@8` and `eslint` blocks that keep it in the dev tree.

| gate | before | after |
| --- | --- | --- |
| `pnpm run build` | 19 tasks successful, exit 0 | 19 tasks successful, exit 0 |
| `pnpm run lint` | 40 tasks successful, exit 0 | 40 tasks successful, exit 0 |
| `pnpm --filter @terrazzo/parser run test` | 25 files, 266 passed, 1 skipped | 25 files, 266 passed, 1 skipped |
| `pnpm --filter @terrazzo/cli run test` | 1 failed, 22 passed | 1 failed, 22 passed |

**One pre-existing failure, stated rather than glossed:** `test/check.test.ts > tz check > valid, npm packages` fails with `Cannot find module 'my-tokens/tokens.json'`. I checked it against the unmodified checkout by stashing the change and re-running — same test, same message, same counts. It looks like the npm-package fixtures need an install step my environment isn't doing, and it is unrelated to this change. I mention it because `@terrazzo/cli` is the parser's main dependent, so it is the package where a bad dependency removal would actually show up.

What a consumer stops installing, measured by resolving `@terrazzo/parser@2.5.0` twice with npm — once as published, once with this dependency removed — and diffing the two lockfiles rather than reasoning about it: **13 entries → 12.** Exactly one package leaves, it is `fast-deep-equal` itself, and nothing new appears.

## On the checklist

Your PR checklist asks for tests. I did not add any, because there is no behaviour here to assert — the change removes a manifest line for a module no code path reaches. The closest thing to a test is the build and the existing suites continuing to pass, which is in the table above. Happy to add something if you have a form of coverage in mind that I have missed.

I ran the parser and cli suites rather than the full `pnpm test`, which stops at the pre-existing `@terrazzo/cli` failure above before reaching the remaining tasks.
