### PR TITLE
Fix $root aliases

### DIFF
--- a/.changeset/stale-stars-melt.md
+++ b/.changeset/stale-stars-melt.md
@@ -1,0 +1,6 @@
+---
+"@terrazzo/cli": patch
+"@terrazzo/parser": patch
+---
+
+Fix bug where $root aliases would sometimes fail if nested

--- a/packages/parser/src/parse/token.ts
+++ b/packages/parser/src/parse/token.ts
@@ -499,8 +499,13 @@ export function resolveAliases(
         if (refChain.includes(nextRef)) {
           logger.error({ ...aliasEntry, message: 'Circular alias detected.' });
         }
-        const nextJSONID = nextRef.replace(/\/(\$value|\$extensions).*/, '');
-        const nextToken = tokens[nextJSONID]?.mode[mode] || tokens[nextJSONID]?.mode['.'];
+        let nextJSONID = nextRef.replace(/\/(\$value|\$extensions).*/, '');
+        let nextToken = tokens[nextJSONID]?.mode[mode] || tokens[nextJSONID]?.mode['.'];
+        // before throwing an error, see if this is a /$root token
+        if (!nextToken) {
+          nextJSONID = `${nextJSONID}/$root`;
+          nextToken = tokens[nextJSONID]?.mode[mode] || tokens[nextJSONID]?.mode['.'];
+        }
         if (!nextToken) {
           logger.error({ ...aliasEntry, message: `Could not resolve alias ${alias}.` });
         }

--- a/packages/parser/test/root.test.ts
+++ b/packages/parser/test/root.test.ts
@@ -128,4 +128,42 @@ describe('$root tokens', () => {
       expect.objectContaining({ aliasedBy: ['color.background.brand'] }),
     );
   });
+
+  it('can be nested', async () => {
+    const filename = new URL('file:///');
+    const src = {
+      color: {
+        text: {
+          brand: {
+            $root: {
+              $type: 'color',
+              $value: { colorSpace: 'srgb', components: [0.46, 0.76, 0.97] },
+            },
+            hover: {
+              $type: 'color',
+              $value: '{color.text.brand}',
+            },
+            secondary: {
+              $root: { $type: 'color', $value: '{color.text.brand}' },
+              hover: { $type: 'color', $value: '{color.text.brand.secondary}' },
+            },
+          },
+        },
+      },
+    };
+    const config = defineConfig({}, { cwd: new URL('file:///') });
+    const { tokens } = await parse([{ filename, src }], { config });
+
+    for (const t of [
+      'color.text.brand',
+      'color.text.brand.secondary',
+      'color.text.brand.secondary.hover',
+    ]) {
+      expect(tokens[t]).toEqual(
+        expect.objectContaining({
+          $value: { colorSpace: 'srgb', components: [0.46, 0.76, 0.97], alpha: 1 },
+        }),
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Changes

In some cases, aliasing to `$root` tokens would fail, especially if referring to the same lineage. Add test and fix bug where lookup forgets to look for `$root` JSON IDs

_Note: JSON IDs are important behavior because they’re unambiguous and easy-to-parse. `…/$root` is clear to the parser it’s referring to a root token and not a group, and reduces many resolution errors. We just forgot to check there for alias resolution before._

## How to Review

- Tests added
