### PR TITLE
fix resolver alias merging

### DIFF
--- a/.changeset/honest-horses-work.md
+++ b/.changeset/honest-horses-work.md
@@ -1,0 +1,6 @@
+---
+"@terrazzo/cli": patch
+"@terrazzo/parser": patch
+---
+
+Fix bug merging raw token value into alias in resolver permutations

--- a/packages/parser/src/lib/resolver-utils.ts
+++ b/packages/parser/src/lib/resolver-utils.ts
@@ -69,7 +69,7 @@ export function destructiveMerge(a: object, b: object): void {
         (a as any)[k] = []; // arrays are overwritten; always make an empty one
         destructiveMerge((a as any)[k], [...b2]); // shallow copy
       } else {
-        if (!(k in a)) {
+        if (typeof (a as any)[k] !== 'object' || !(k in a)) {
           (a as any)[k] = {}; // objects are merged; create empty one if none exists
         }
         destructiveMerge((a as any)[k], { ...b2 }); // shallow copy

--- a/packages/parser/test/lib/resolver-utils.test.ts
+++ b/packages/parser/test/lib/resolver-utils.test.ts
@@ -85,6 +85,16 @@ describe('descructiveMerge', () => {
     ],
     ['undefined (one)', { given: [undefined, { b: 2 }], want: undefined }],
     ['undefined (both)', { given: [undefined, undefined], want: undefined }],
+    [
+      'string -> object',
+      {
+        given: [
+          { $type: 'color', $value: '{color.white.1000}' },
+          { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+        ],
+        want: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+      },
+    ],
   ];
   it.each(tests)('%s', (_, { given: [a, b], want }) => {
     destructiveMerge(a, b);

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -430,6 +430,67 @@ describe('Resolver module', () => {
         }),
       );
     });
+
+    it('raw value overrides alias correctly', async () => {
+      const config = defineConfig({}, { cwd: new URL(import.meta.url) });
+      const { resolver } = await parse(
+        [
+          {
+            filename: new URL('file:///'),
+            src: JSON.stringify({
+              version: '2025.10',
+              resolutionOrder: [
+                { $ref: '#/sets/primitive' },
+                { $ref: '#/sets/semantic' },
+                { $ref: '#/modifiers/theme' },
+              ],
+              sets: {
+                primitive: {
+                  sources: [
+                    {
+                      ramp: {
+                        100: {
+                          $type: 'color',
+                          $value: { colorSpace: 'srgb', components: [0.95, 0.95, 0.95] },
+                        },
+                      },
+                    },
+                  ],
+                },
+                semantic: {
+                  sources: [{ color: { bg: { $type: 'color', $value: '{ramp.100}' } } }],
+                },
+              },
+              modifiers: {
+                theme: {
+                  contexts: {
+                    light: [],
+                    'light-ec': [
+                      {
+                        color: {
+                          bg: {
+                            $type: 'color',
+                            $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            }),
+          },
+        ],
+        { config },
+      );
+
+      const lightEcTokens = resolver.apply({ theme: 'light-ec' });
+      expect(lightEcTokens['color.bg']).toEqual(
+        expect.objectContaining({
+          $value: { colorSpace: 'srgb', components: [1, 1, 1], alpha: 1 },
+        }),
+      );
+    });
   });
 
   describe('additional cases', () => {


### PR DESCRIPTION
## Changes

Fix bug where if a resolver declared a string alias followed by a raw object value, there’d be an error trying to flatten the structure. Fixes that and adds tests.

## How to Review

- Tests added
