### PR TITLE
fix(token-tools): don't emit undefined for non-object dimensions

### DIFF
--- a/.changeset/typography-string-subvalues.md
+++ b/.changeset/typography-string-subvalues.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/token-tools": patch
+---
+
+Fix dimension values that aren't `{ value, unit }` objects emitting `undefinedundefined`

--- a/packages/plugin-css/test/fixtures/ds-microsoft-fluent/fluent.want.css
+++ b/packages/plugin-css/test/fixtures/ds-microsoft-fluent/fluent.want.css
@@ -17,7 +17,7 @@
   --fonts-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-large-font-size: 18px;
   --fonts-large-font-weight: 400;
-  --fonts-large-letter-spacing: undefinedundefined;
+  --fonts-large-letter-spacing: 0;
   --fonts-large-line-height: 1;
   --fonts-medium: var(--fonts-medium-font-weight) var(--fonts-medium-font-size)/var(--fonts-medium-line-height) var(--fonts-medium-font-family);
   --fonts-medium--moz-osx-font-smoothing: grayscale;
@@ -25,7 +25,7 @@
   --fonts-medium-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-medium-font-size: 14px;
   --fonts-medium-font-weight: 400;
-  --fonts-medium-letter-spacing: undefinedundefined;
+  --fonts-medium-letter-spacing: 0;
   --fonts-medium-line-height: 1;
   --fonts-medium-plus: var(--fonts-medium-plus-font-weight) var(--fonts-medium-plus-font-size)/var(--fonts-medium-plus-line-height) var(--fonts-medium-plus-font-family);
   --fonts-medium-plus--moz-osx-font-smoothing: grayscale;
@@ -33,7 +33,7 @@
   --fonts-medium-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-medium-plus-font-size: 16px;
   --fonts-medium-plus-font-weight: 400;
-  --fonts-medium-plus-letter-spacing: undefinedundefined;
+  --fonts-medium-plus-letter-spacing: 0;
   --fonts-medium-plus-line-height: 1;
   --fonts-mega: var(--fonts-mega-font-weight) var(--fonts-mega-font-size)/var(--fonts-mega-line-height) var(--fonts-mega-font-family);
   --fonts-mega--moz-osx-font-smoothing: grayscale;
@@ -41,7 +41,7 @@
   --fonts-mega-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-mega-font-size: 68px;
   --fonts-mega-font-weight: 600;
-  --fonts-mega-letter-spacing: undefinedundefined;
+  --fonts-mega-letter-spacing: 0;
   --fonts-mega-line-height: 1;
   --fonts-small: var(--fonts-small-font-weight) var(--fonts-small-font-size)/var(--fonts-small-line-height) var(--fonts-small-font-family);
   --fonts-small--moz-osx-font-smoothing: grayscale;
@@ -49,7 +49,7 @@
   --fonts-small-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-small-font-size: 12px;
   --fonts-small-font-weight: 400;
-  --fonts-small-letter-spacing: undefinedundefined;
+  --fonts-small-letter-spacing: 0;
   --fonts-small-line-height: 1;
   --fonts-small-plus: var(--fonts-small-plus-font-weight) var(--fonts-small-plus-font-size)/var(--fonts-small-plus-line-height) var(--fonts-small-plus-font-family);
   --fonts-small-plus--moz-osx-font-smoothing: grayscale;
@@ -57,7 +57,7 @@
   --fonts-small-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-small-plus-font-size: 12px;
   --fonts-small-plus-font-weight: 400;
-  --fonts-small-plus-letter-spacing: undefinedundefined;
+  --fonts-small-plus-letter-spacing: 0;
   --fonts-small-plus-line-height: 1;
   --fonts-super-large: var(--fonts-super-large-font-weight) var(--fonts-super-large-font-size)/var(--fonts-super-large-line-height) var(--fonts-super-large-font-family);
   --fonts-super-large--moz-osx-font-smoothing: grayscale;
@@ -65,7 +65,7 @@
   --fonts-super-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-super-large-font-size: 42px;
   --fonts-super-large-font-weight: 600;
-  --fonts-super-large-letter-spacing: undefinedundefined;
+  --fonts-super-large-letter-spacing: 0;
   --fonts-super-large-line-height: 1;
   --fonts-tiny: var(--fonts-tiny-font-weight) var(--fonts-tiny-font-size)/var(--fonts-tiny-line-height) var(--fonts-tiny-font-family);
   --fonts-tiny--moz-osx-font-smoothing: grayscale;
@@ -73,7 +73,7 @@
   --fonts-tiny-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-tiny-font-size: 10px;
   --fonts-tiny-font-weight: 400;
-  --fonts-tiny-letter-spacing: undefinedundefined;
+  --fonts-tiny-letter-spacing: 0;
   --fonts-tiny-line-height: 1;
   --fonts-x-large: var(--fonts-x-large-font-weight) var(--fonts-x-large-font-size)/var(--fonts-x-large-line-height) var(--fonts-x-large-font-family);
   --fonts-x-large--moz-osx-font-smoothing: grayscale;
@@ -81,7 +81,7 @@
   --fonts-x-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-x-large-font-size: 20px;
   --fonts-x-large-font-weight: 600;
-  --fonts-x-large-letter-spacing: undefinedundefined;
+  --fonts-x-large-letter-spacing: 0;
   --fonts-x-large-line-height: 1;
   --fonts-x-large-plus: var(--fonts-x-large-plus-font-weight) var(--fonts-x-large-plus-font-size)/var(--fonts-x-large-plus-line-height) var(--fonts-x-large-plus-font-family);
   --fonts-x-large-plus--moz-osx-font-smoothing: grayscale;
@@ -89,7 +89,7 @@
   --fonts-x-large-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-x-large-plus-font-size: 24px;
   --fonts-x-large-plus-font-weight: 600;
-  --fonts-x-large-plus-letter-spacing: undefinedundefined;
+  --fonts-x-large-plus-letter-spacing: 0;
   --fonts-x-large-plus-line-height: 1;
   --fonts-x-small: var(--fonts-x-small-font-weight) var(--fonts-x-small-font-size)/var(--fonts-x-small-line-height) var(--fonts-x-small-font-family);
   --fonts-x-small--moz-osx-font-smoothing: grayscale;
@@ -97,7 +97,7 @@
   --fonts-x-small-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-x-small-font-size: 10px;
   --fonts-x-small-font-weight: 400;
-  --fonts-x-small-letter-spacing: undefinedundefined;
+  --fonts-x-small-letter-spacing: 0;
   --fonts-x-small-line-height: 1;
   --fonts-xx-large: var(--fonts-xx-large-font-weight) var(--fonts-xx-large-font-size)/var(--fonts-xx-large-line-height) var(--fonts-xx-large-font-family);
   --fonts-xx-large--moz-osx-font-smoothing: grayscale;
@@ -105,7 +105,7 @@
   --fonts-xx-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-xx-large-font-size: 28px;
   --fonts-xx-large-font-weight: 600;
-  --fonts-xx-large-letter-spacing: undefinedundefined;
+  --fonts-xx-large-letter-spacing: 0;
   --fonts-xx-large-line-height: 1;
   --fonts-xx-large-plus: var(--fonts-xx-large-plus-font-weight) var(--fonts-xx-large-plus-font-size)/var(--fonts-xx-large-plus-line-height) var(--fonts-xx-large-plus-font-family);
   --fonts-xx-large-plus--moz-osx-font-smoothing: grayscale;
@@ -113,7 +113,7 @@
   --fonts-xx-large-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-xx-large-plus-font-size: 32px;
   --fonts-xx-large-plus-font-weight: 600;
-  --fonts-xx-large-plus-letter-spacing: undefinedundefined;
+  --fonts-xx-large-plus-letter-spacing: 0;
   --fonts-xx-large-plus-line-height: 1;
   --palette-accent: rgb(0% 47.059% 83.137%);
   --palette-black: rgb(0% 0% 0%);
@@ -290,7 +290,7 @@
   --fonts-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-large-font-size: 18px;
   --fonts-large-font-weight: 400;
-  --fonts-large-letter-spacing: undefinedundefined;
+  --fonts-large-letter-spacing: 0;
   --fonts-large-line-height: 1;
   --fonts-medium: var(--fonts-medium-font-weight) var(--fonts-medium-font-size)/var(--fonts-medium-line-height) var(--fonts-medium-font-family);
   --fonts-medium--moz-osx-font-smoothing: grayscale;
@@ -298,7 +298,7 @@
   --fonts-medium-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-medium-font-size: 14px;
   --fonts-medium-font-weight: 400;
-  --fonts-medium-letter-spacing: undefinedundefined;
+  --fonts-medium-letter-spacing: 0;
   --fonts-medium-line-height: 1;
   --fonts-medium-plus: var(--fonts-medium-plus-font-weight) var(--fonts-medium-plus-font-size)/var(--fonts-medium-plus-line-height) var(--fonts-medium-plus-font-family);
   --fonts-medium-plus--moz-osx-font-smoothing: grayscale;
@@ -306,7 +306,7 @@
   --fonts-medium-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-medium-plus-font-size: 16px;
   --fonts-medium-plus-font-weight: 400;
-  --fonts-medium-plus-letter-spacing: undefinedundefined;
+  --fonts-medium-plus-letter-spacing: 0;
   --fonts-medium-plus-line-height: 1;
   --fonts-mega: var(--fonts-mega-font-weight) var(--fonts-mega-font-size)/var(--fonts-mega-line-height) var(--fonts-mega-font-family);
   --fonts-mega--moz-osx-font-smoothing: grayscale;
@@ -314,7 +314,7 @@
   --fonts-mega-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-mega-font-size: 68px;
   --fonts-mega-font-weight: 600;
-  --fonts-mega-letter-spacing: undefinedundefined;
+  --fonts-mega-letter-spacing: 0;
   --fonts-mega-line-height: 1;
   --fonts-small: var(--fonts-small-font-weight) var(--fonts-small-font-size)/var(--fonts-small-line-height) var(--fonts-small-font-family);
   --fonts-small--moz-osx-font-smoothing: grayscale;
@@ -322,7 +322,7 @@
   --fonts-small-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-small-font-size: 12px;
   --fonts-small-font-weight: 400;
-  --fonts-small-letter-spacing: undefinedundefined;
+  --fonts-small-letter-spacing: 0;
   --fonts-small-line-height: 1;
   --fonts-small-plus: var(--fonts-small-plus-font-weight) var(--fonts-small-plus-font-size)/var(--fonts-small-plus-line-height) var(--fonts-small-plus-font-family);
   --fonts-small-plus--moz-osx-font-smoothing: grayscale;
@@ -330,7 +330,7 @@
   --fonts-small-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-small-plus-font-size: 12px;
   --fonts-small-plus-font-weight: 400;
-  --fonts-small-plus-letter-spacing: undefinedundefined;
+  --fonts-small-plus-letter-spacing: 0;
   --fonts-small-plus-line-height: 1;
   --fonts-super-large: var(--fonts-super-large-font-weight) var(--fonts-super-large-font-size)/var(--fonts-super-large-line-height) var(--fonts-super-large-font-family);
   --fonts-super-large--moz-osx-font-smoothing: grayscale;
@@ -338,7 +338,7 @@
   --fonts-super-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-super-large-font-size: 42px;
   --fonts-super-large-font-weight: 600;
-  --fonts-super-large-letter-spacing: undefinedundefined;
+  --fonts-super-large-letter-spacing: 0;
   --fonts-super-large-line-height: 1;
   --fonts-tiny: var(--fonts-tiny-font-weight) var(--fonts-tiny-font-size)/var(--fonts-tiny-line-height) var(--fonts-tiny-font-family);
   --fonts-tiny--moz-osx-font-smoothing: grayscale;
@@ -346,7 +346,7 @@
   --fonts-tiny-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-tiny-font-size: 10px;
   --fonts-tiny-font-weight: 400;
-  --fonts-tiny-letter-spacing: undefinedundefined;
+  --fonts-tiny-letter-spacing: 0;
   --fonts-tiny-line-height: 1;
   --fonts-x-large: var(--fonts-x-large-font-weight) var(--fonts-x-large-font-size)/var(--fonts-x-large-line-height) var(--fonts-x-large-font-family);
   --fonts-x-large--moz-osx-font-smoothing: grayscale;
@@ -354,7 +354,7 @@
   --fonts-x-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-x-large-font-size: 20px;
   --fonts-x-large-font-weight: 600;
-  --fonts-x-large-letter-spacing: undefinedundefined;
+  --fonts-x-large-letter-spacing: 0;
   --fonts-x-large-line-height: 1;
   --fonts-x-large-plus: var(--fonts-x-large-plus-font-weight) var(--fonts-x-large-plus-font-size)/var(--fonts-x-large-plus-line-height) var(--fonts-x-large-plus-font-family);
   --fonts-x-large-plus--moz-osx-font-smoothing: grayscale;
@@ -362,7 +362,7 @@
   --fonts-x-large-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-x-large-plus-font-size: 24px;
   --fonts-x-large-plus-font-weight: 600;
-  --fonts-x-large-plus-letter-spacing: undefinedundefined;
+  --fonts-x-large-plus-letter-spacing: 0;
   --fonts-x-large-plus-line-height: 1;
   --fonts-x-small: var(--fonts-x-small-font-weight) var(--fonts-x-small-font-size)/var(--fonts-x-small-line-height) var(--fonts-x-small-font-family);
   --fonts-x-small--moz-osx-font-smoothing: grayscale;
@@ -370,7 +370,7 @@
   --fonts-x-small-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-x-small-font-size: 10px;
   --fonts-x-small-font-weight: 400;
-  --fonts-x-small-letter-spacing: undefinedundefined;
+  --fonts-x-small-letter-spacing: 0;
   --fonts-x-small-line-height: 1;
   --fonts-xx-large: var(--fonts-xx-large-font-weight) var(--fonts-xx-large-font-size)/var(--fonts-xx-large-line-height) var(--fonts-xx-large-font-family);
   --fonts-xx-large--moz-osx-font-smoothing: grayscale;
@@ -378,7 +378,7 @@
   --fonts-xx-large-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-xx-large-font-size: 28px;
   --fonts-xx-large-font-weight: 600;
-  --fonts-xx-large-letter-spacing: undefinedundefined;
+  --fonts-xx-large-letter-spacing: 0;
   --fonts-xx-large-line-height: 1;
   --fonts-xx-large-plus: var(--fonts-xx-large-plus-font-weight) var(--fonts-xx-large-plus-font-size)/var(--fonts-xx-large-plus-line-height) var(--fonts-xx-large-plus-font-family);
   --fonts-xx-large-plus--moz-osx-font-smoothing: grayscale;
@@ -386,7 +386,7 @@
   --fonts-xx-large-plus-font-family: "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif";
   --fonts-xx-large-plus-font-size: 32px;
   --fonts-xx-large-plus-font-weight: 600;
-  --fonts-xx-large-plus-letter-spacing: undefinedundefined;
+  --fonts-xx-large-plus-letter-spacing: 0;
   --fonts-xx-large-plus-line-height: 1;
   --palette-accent: rgb(0% 47.059% 83.137%);
   --palette-black: rgb(0% 0% 0%);

--- a/packages/token-tools/src/css/dimension.ts
+++ b/packages/token-tools/src/css/dimension.ts
@@ -12,5 +12,12 @@ export function transformDimension(
     return transformAlias(tokensSet[token.aliasChain[0]]!);
   }
 
+  // Legacy string dimensions, bare numbers and CSS keywords reach here too:
+  // `core/valid-dimension` reports them, but the parser still passes them through.
+  const $value = token.$value as unknown;
+  if (typeof $value === 'string' || typeof $value === 'number') {
+    return String($value);
+  }
+
   return `${token.$value.value}${token.$value.unit}`;
 }

--- a/packages/token-tools/src/css/typography.ts
+++ b/packages/token-tools/src/css/typography.ts
@@ -8,6 +8,7 @@ import type {
   Token,
   TokenNormalized,
   TokenTransformedMultiValue,
+  TokenTransformedSingleValue,
   TypographyTokenNormalized,
 } from '../types.js';
 import type { TransformCSSValueOptions } from './css-types.js';
@@ -17,6 +18,24 @@ import { transformFontWeight } from './font-weight.js';
 import { defaultAliasTransform } from './lib.js';
 import { transformNumber } from './number.js';
 import { transformString } from './string.js';
+
+/**
+ * Transform a sub-value by its actual shape rather than by the property it
+ * arrived under: the dimension slots also carry numbers and CSS keywords.
+ */
+function transformDimensionLike(
+  subvalue: unknown,
+  options: TransformCSSValueOptions,
+): TokenTransformedSingleValue['value'] {
+  if (subvalue && typeof subvalue === 'object' && 'value' in subvalue) {
+    return transformDimension({ $value: subvalue } as DimensionTokenNormalized, options);
+  }
+  // number is allowed for `line-height: 1.5` and `paragraph-spacing: 0`
+  if (typeof subvalue === 'number') {
+    return transformNumber({ $value: subvalue } as NumberTokenNormalized, options);
+  }
+  return transformString({ $value: subvalue } as StringTokenNormalized, options);
+}
 
 /** Convert typography value to multiple CSS values */
 export function transformTypography(
@@ -50,14 +69,6 @@ export function transformTypography(
           );
           break;
         }
-        case 'fontSize':
-        case 'letterSpacing': {
-          transformedValue = transformDimension(
-            { $value: subvalue } as DimensionTokenNormalized,
-            options,
-          );
-          break;
-        }
         case 'fontWeight': {
           transformedValue = transformFontWeight(
             { $value: subvalue } as FontWeightTokenNormalized,
@@ -65,39 +76,8 @@ export function transformTypography(
           );
           break;
         }
-        case 'lineHeight': {
-          if (typeof subvalue === 'number') {
-            transformedValue = transformNumber(
-              { $value: subvalue } as NumberTokenNormalized,
-              options,
-            );
-          } else {
-            transformedValue = transformDimension(
-              { $value: subvalue } as DimensionTokenNormalized,
-              options,
-            );
-          }
-          break;
-        }
         default: {
-          // For other typography properties, dimensions are the only other likely token type
-          if (subvalue && typeof subvalue === 'object' && 'value' in subvalue) {
-            transformedValue = transformDimension(
-              { $value: subvalue } as DimensionTokenNormalized,
-              options,
-            );
-          } else if (typeof subvalue === 'number') {
-            // number is technically allowed for things like `paragraph-spacing: 0`
-            transformedValue = transformNumber(
-              { $value: subvalue } as NumberTokenNormalized,
-              options,
-            );
-          } else {
-            transformedValue = transformString(
-              { $value: subvalue } as StringTokenNormalized,
-              options,
-            );
-          }
+          transformedValue = transformDimensionLike(subvalue, options);
           break;
         }
       }

--- a/packages/token-tools/test/css.test.ts
+++ b/packages/token-tools/test/css.test.ts
@@ -570,6 +570,20 @@ describe('transformDimension', () => {
       },
     ],
     [
+      'legacy string value',
+      {
+        given: [{ $value: '1rem' }, { tokensSet: {}, permutation: {} }],
+        want: { success: '1rem' },
+      },
+    ],
+    [
+      'bare number value',
+      {
+        given: [{ $value: 0 }, { tokensSet: {}, permutation: {} }],
+        want: { success: '0' },
+      },
+    ],
+    [
       '0.75em',
       {
         given: [{ $value: { value: 0.75, unit: 'em' } }, { tokensSet: {}, permutation: {} }],
@@ -936,6 +950,88 @@ describe('transformTypography', () => {
         want: {
           success: {
             'font-family': 'var(--font-sans-font-family)',
+          },
+        },
+      },
+    ],
+    [
+      'keyword subvalues',
+      {
+        given: [
+          {
+            $value: {
+              fontSize: 'inherit',
+              letterSpacing: 'normal',
+              lineHeight: 'normal',
+            },
+          },
+          { tokensSet: {}, permutation: {} },
+        ],
+        want: {
+          success: {
+            'font-size': 'inherit',
+            'letter-spacing': 'normal',
+            'line-height': 'normal',
+          },
+        },
+      },
+    ],
+    [
+      'legacy string dimensions',
+      {
+        given: [
+          {
+            $value: {
+              fontSize: '1rem',
+              letterSpacing: '0.125em',
+              lineHeight: '1.5',
+            },
+          },
+          { tokensSet: {}, permutation: {} },
+        ],
+        want: {
+          success: {
+            'font-size': '1rem',
+            'letter-spacing': '0.125em',
+            'line-height': '1.5',
+          },
+        },
+      },
+    ],
+    [
+      'numeric lineHeight stays unitless',
+      {
+        given: [
+          {
+            $value: {
+              fontSize: { value: 16, unit: 'px' },
+              lineHeight: 1.5,
+            },
+          },
+          { tokensSet: {}, permutation: {} },
+        ],
+        want: {
+          success: {
+            'font-size': '16px',
+            'line-height': '1.5',
+          },
+        },
+      },
+    ],
+    [
+      'bare numeric letterSpacing',
+      {
+        given: [
+          {
+            $value: {
+              letterSpacing: 0,
+            },
+          },
+          { tokensSet: {}, permutation: {} },
+        ],
+        want: {
+          success: {
+            'letter-spacing': '0',
           },
         },
       },


### PR DESCRIPTION
## Changes

`transformDimension` reads `.value` / `.unit` off `$value`, so anything that isn't a `{ value, unit }` object emits `undefinedundefined`:

    --fonts-medium-letter-spacing: undefinedundefined;

Hits bare numbers (`0`), legacy strings (`"1rem"`), and keywords (`"normal"`). The guard goes in `transformDimension`, so it covers every dimension slot, not just typography.

Related: #820 and #823, it resolves aliases to literals, literals which are fixed in this PR. This PR should be merged before #823.

## How to Review

- **Snapshot first.** `fluent.want.css`: 26 lines, all `undefinedundefined` → `0`.
  Microsoft Fluent sets `"letterSpacing": 0`, so the broken output was committed as expected output.
- `dimension.ts`:  4-line guard.
- `typography.ts`: three `case` branches are deleted. They fall through to `default:` which already did this right.

`pnpm --filter @terrazzo/token-tools test`: 6 new cases.