### PR TITLE
fix(plugin-css): resolve aliases in @property initial-value

### DIFF
--- a/.changeset/property-defs-resolve-aliases.md
+++ b/.changeset/property-defs-resolve-aliases.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-css": patch
+---
+
+Fix `propertyDefinitions` generating invalid `initial-value: var(--…)` for aliased values. Aliases are now resolved to their literal value at build time, so aliased tokens get a typed `syntax` instead of `'*'`.

--- a/packages/plugin-css/src/build.ts
+++ b/packages/plugin-css/src/build.ts
@@ -99,6 +99,14 @@ function generatePropertyDefinition(
   return rule([`@property ${localID}`], children);
 }
 
+const FULL_VAR_REF_RE = /^var\((--[^)]+)\)$/;
+
+// Anything still containing var() after alias resolution (e.g. a reference
+// inside a shadow layer) can't be an initial-value.
+function isIndependent(value: string): boolean {
+  return !value.includes('var(');
+}
+
 function generatePropertyDefinitions(
   getTransforms: BuildHookOptions['getTransforms'],
   options: { include: (id: string) => boolean; exclude: (id: string) => boolean },
@@ -123,7 +131,6 @@ function generatePropertyDefinitions(
       }
     }
   }
-  const FULL_VAR_REF_RE = /^var\((--[^)]+)\)$/;
   function resolveInitialValue(value: string, depth = 0): string {
     const ref = value.match(FULL_VAR_REF_RE);
     if (!ref || depth > 10) {
@@ -132,12 +139,6 @@ function generatePropertyDefinitions(
     const target = valueByLocalID.get(ref[1]!);
     return target === undefined ? value : resolveInitialValue(target, depth + 1);
   }
-  // Anything still containing var() after resolution (e.g. a reference inside
-  // a shadow layer) can't be an initial-value.
-  function isIndependent(value: string): boolean {
-    return !value.includes('var(');
-  }
-
   for (const token of tokens) {
     const localID = token.localID;
     if (!localID) {

--- a/packages/plugin-css/src/build.ts
+++ b/packages/plugin-css/src/build.ts
@@ -107,6 +107,37 @@ function generatePropertyDefinitions(
   const properties: CSSRule[] = [];
   const seen = new Set<string>();
 
+  // @property initial-value can't contain var() references as the rule would be
+  // invalid. Aliases are resolvable at build time though: so we resolve them to their
+  // literal values then aliased tokens keep a typed syntax instead of '*'
+  const valueByLocalID = new Map<string, string>();
+  for (const token of tokens) {
+    if (!token.localID || token.mode !== '.') {
+      continue;
+    }
+    if (token.type === 'SINGLE_VALUE' && typeof token.value === 'string') {
+      valueByLocalID.set(token.localID, token.value);
+    } else if (token.type === 'MULTI_VALUE') {
+      for (const [name, subValue] of Object.entries(token.value)) {
+        valueByLocalID.set(name === '.' ? token.localID : `${token.localID}-${name}`, subValue);
+      }
+    }
+  }
+  const FULL_VAR_REF_RE = /^var\((--[^)]+)\)$/;
+  function resolveInitialValue(value: string, depth = 0): string {
+    const ref = value.match(FULL_VAR_REF_RE);
+    if (!ref || depth > 10) {
+      return value;
+    }
+    const target = valueByLocalID.get(ref[1]!);
+    return target === undefined ? value : resolveInitialValue(target, depth + 1);
+  }
+  // Anything still containing var() after resolution (e.g. a reference inside
+  // a shadow layer) can't be an initial-value.
+  function isIndependent(value: string): boolean {
+    return !value.includes('var(');
+  }
+
   for (const token of tokens) {
     const localID = token.localID;
     if (!localID) {
@@ -123,8 +154,9 @@ function generatePropertyDefinitions(
         continue;
       }
       seen.add(localID);
-      if (!token.token.aliasOf && cssSyntax !== '*') {
-        properties.push(generatePropertyDefinition(localID, cssSyntax, token.value));
+      const value = resolveInitialValue(token.value);
+      if (cssSyntax !== '*' && isIndependent(value)) {
+        properties.push(generatePropertyDefinition(localID, cssSyntax, value));
       } else {
         properties.push(generatePropertyDefinition(localID, '*'));
       }
@@ -136,8 +168,9 @@ function generatePropertyDefinitions(
         }
         seen.add(subID);
         const subSyntax = SUB_PROPERTY_SYNTAX[token.token.$type]?.[name] ?? '*';
-        if (!token.token.aliasOf && subSyntax !== '*') {
-          properties.push(generatePropertyDefinition(subID, subSyntax, subValue));
+        const value = resolveInitialValue(subValue);
+        if (subSyntax !== '*' && isIndependent(value)) {
+          properties.push(generatePropertyDefinition(subID, subSyntax, value));
         } else {
           properties.push(generatePropertyDefinition(subID, '*'));
         }

--- a/packages/plugin-css/test/fixtures/option-property-defs/index.want.css
+++ b/packages/plugin-css/test/fixtures/option-property-defs/index.want.css
@@ -3,8 +3,15 @@
  * ------------------------------------------- */
 
 @property --color-alias {
-  syntax: '*';
+  syntax: '<color>';
   inherits: true;
+  initial-value: rgb(0% 0% 100%);
+}
+
+@property --color-alias-2 {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: rgb(0% 0% 100%);
 }
 
 @property --color-blue {
@@ -13,14 +20,60 @@
   initial-value: rgb(0% 0% 100%);
 }
 
+@property --shadow-focus {
+  syntax: '*';
+  inherits: true;
+}
+
 @property --space-md {
   syntax: '<length>';
   inherits: true;
   initial-value: 16px;
 }
 
+@property --type-heading-font-family {
+  syntax: '*';
+  inherits: true;
+}
+
+@property --type-heading-font-size {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 2rem;
+}
+
+@property --type-heading-font-weight {
+  syntax: '<integer>';
+  inherits: true;
+  initial-value: 700;
+}
+
+@property --type-heading-line-height {
+  syntax: '*';
+  inherits: true;
+}
+
+@property --type-heading {
+  syntax: '*';
+  inherits: true;
+}
+
+@property --type-size-lg {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 2rem;
+}
+
 :root {
   --color-alias: var(--color-blue);
+  --color-alias-2: var(--color-alias);
   --color-blue: rgb(0% 0% 100%);
+  --shadow-focus: 0px 0px 0px 2px var(--color-blue);
   --space-md: 16px;
+  --type-heading-font-family: "Inter", sans-serif;
+  --type-heading-font-size: var(--type-size-lg);
+  --type-heading-font-weight: 700;
+  --type-heading-line-height: 1.2;
+  --type-heading: var(--type-heading-font-weight) var(--type-heading-font-size)/var(--type-heading-line-height) var(--type-heading-font-family);
+  --type-size-lg: 2rem;
 }

--- a/packages/plugin-css/test/fixtures/option-property-defs/tokens.json
+++ b/packages/plugin-css/test/fixtures/option-property-defs/tokens.json
@@ -7,12 +7,74 @@
     "alias": {
       "$type": "color",
       "$value": "{color.blue}"
+    },
+    "alias-2": {
+      "$type": "color",
+      "$value": "{color.alias}"
     }
   },
   "space": {
     "md": {
       "$type": "dimension",
-      "$value": { "value": 16, "unit": "px" }
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      }
+    }
+  },
+  "type": {
+    "size": {
+      "lg": {
+        "$type": "dimension",
+        "$value": {
+          "value": 2,
+          "unit": "rem"
+        },
+        "$extensions": {
+          "mode": {
+            "desktop": {
+              "value": 3,
+              "unit": "rem"
+            }
+          }
+        }
+      }
+    },
+    "heading": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": [
+          "Inter",
+          "sans-serif"
+        ],
+        "fontSize": "{type.size.lg}",
+        "fontWeight": 700,
+        "lineHeight": 1.2
+      }
+    }
+  },
+  "shadow": {
+    "focus": {
+      "$type": "shadow",
+      "$value": {
+        "offsetX": {
+          "value": 0,
+          "unit": "px"
+        },
+        "offsetY": {
+          "value": 0,
+          "unit": "px"
+        },
+        "blur": {
+          "value": 0,
+          "unit": "px"
+        },
+        "spread": {
+          "value": 2,
+          "unit": "px"
+        },
+        "color": "{color.blue}"
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes [#820](https://github.com/yannbf/life/issues/820)

## Changes
`generatePropertyDefinitions` now indexes the transformed values by custom property name and resolves `var()` references down to their literal value. As a bonus, aliased scalar tokens (like a color aliasing another color) now keep their typed syntax and get a real `initial-value` instead of `'*'`! 

Values that still contain `var()` after resolution (like a reference inside a shadow layer) fall back to `syntax: '*'` as before.

## How to Review

Check the diff in `packages/plugin-css/test/fixtures/option-property-defs/index.want.css`