### PR TITLE
fix(cli): harden Figma-to-DTCG imports

### DIFF
--- a/.changeset/calm-font-weights.md
+++ b/.changeset/calm-font-weights.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/parser": patch
+---
+
+Align `core/valid-font-weight` with DTCG 2025.10 by accepting numeric weights from 1 through 1000 inclusive.

--- a/.changeset/fuzzy-geese-import.md
+++ b/.changeset/fuzzy-geese-import.md
@@ -2,4 +2,4 @@
 "@terrazzo/cli": minor
 ---
 
-Add resolved-type-safe Figma variable overrides for duration and cubic Bézier tokens, preserve resolver order during updates, and emit DTCG-valid typography, effect, and grid style values. Unmapped STRING and BOOLEAN Variables remain compatibility types outside the strict DTCG type enum.
+Add alias-safe Figma variable overrides for duration, cubic Bézier, font, and number tokens; preserve resolver order during updates; and emit DTCG-valid typography, effect, and grid style values. The new `--number-float-names` option provides resolved-type-safe number matching while deprecated `--number-names` retains its historical primitive coercion. Unmapped STRING and BOOLEAN Variables remain compatibility types outside the strict DTCG type enum.

--- a/.changeset/fuzzy-geese-import.md
+++ b/.changeset/fuzzy-geese-import.md
@@ -2,4 +2,4 @@
 "@terrazzo/cli": minor
 ---
 
-Add alias-safe Figma variable overrides for duration, cubic Bézier, font, and number tokens; preserve resolver order during updates; and emit DTCG-valid typography, effect, and grid style values. The new `--number-float-names` option provides resolved-type-safe number matching while deprecated `--number-names` retains its historical primitive coercion. Unmapped STRING and BOOLEAN Variables remain compatibility types outside the strict DTCG type enum.
+Add alias-safe Figma variable overrides for duration, cubic Bézier, font, and number tokens; preserve resolver order during updates; and emit DTCG-valid typography, effect, and grid style values. The new `--number-float-names` option provides resolved-type-safe number matching while deprecated `--number-names` retains finite primitive coercion without emitting invalid numeric values. Incompatible overlapping matchers now preserve Figma types for the entire alias chain. Unmapped STRING and BOOLEAN Variables remain compatibility types outside the strict DTCG type enum.

--- a/.changeset/fuzzy-geese-import.md
+++ b/.changeset/fuzzy-geese-import.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/cli": minor
+---
+
+Add resolved-type-safe Figma variable overrides for duration and cubic Bézier tokens, preserve resolver order during updates, and emit valid typography, effect, and grid style values.

--- a/.changeset/fuzzy-geese-import.md
+++ b/.changeset/fuzzy-geese-import.md
@@ -2,4 +2,4 @@
 "@terrazzo/cli": minor
 ---
 
-Add resolved-type-safe Figma variable overrides for duration and cubic Bézier tokens, preserve resolver order during updates, and emit valid typography, effect, and grid style values.
+Add resolved-type-safe Figma variable overrides for duration and cubic Bézier tokens, preserve resolver order during updates, and emit DTCG-valid typography, effect, and grid style values. Unmapped STRING and BOOLEAN Variables remain compatibility types outside the strict DTCG type enum.

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -73,6 +73,8 @@ const { values: flags, positionals } = parseArgs({
     'font-family-names': { type: 'string' },
     'font-weight-names': { type: 'string' },
     'number-names': { type: 'string' },
+    'duration-names': { type: 'string' },
+    'cubic-bezier-names': { type: 'string' },
   },
 });
 

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -73,6 +73,7 @@ const { values: flags, positionals } = parseArgs({
     'font-family-names': { type: 'string' },
     'font-weight-names': { type: 'string' },
     'number-names': { type: 'string' },
+    'number-float-names': { type: 'string' },
     'duration-names': { type: 'string' },
     'cubic-bezier-names': { type: 'string' },
   },

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -19,6 +19,16 @@ export function helpCmd() {
       --skip-styles  Don’t import styles
       --skip-variables
                      Don’t import variables
+      --font-family-names [regex]
+                     Override matching STRING Variables as fontFamily
+      --font-weight-names [regex]
+                     Override matching FLOAT or STRING Variables as fontWeight
+      --number-names [regex]
+                     Override matching FLOAT Variables as number
+      --duration-names [regex]
+                     Override matching STRING Variables as duration
+      --cubic-bezier-names [regex]
+                     Override matching STRING Variables as cubicBezier
 
   [options]
     --help           Show this message

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -15,7 +15,7 @@ export function helpCmd() {
     lab              Manage your tokens with a web interface
     import [path]    Import from a Figma Design file
       --o [file]     Save imported JSON
-      --unpublished  Include unpublished Variables
+      --unpublished  Include unpublished Styles and Variables
       --skip-styles  Don’t import styles
       --skip-variables
                      Don’t import variables
@@ -24,6 +24,8 @@ export function helpCmd() {
       --font-weight-names [regex]
                      Override matching FLOAT or STRING Variables as fontWeight
       --number-names [regex]
+                     Deprecated: coerce matching primitives as number
+      --number-float-names [regex]
                      Override matching FLOAT Variables as number
       --duration-names [regex]
                      Override matching STRING Variables as duration

--- a/packages/cli/src/import/figma/index.ts
+++ b/packages/cli/src/import/figma/index.ts
@@ -65,7 +65,10 @@ export async function importFromFigma({
     code: {
       $schema: 'https://www.designtokens.org/schemas/2025.10/resolver.json',
       version: '2025.10',
-      resolutionOrder: resolutionOrder?.map((entry) => ({ ...entry })) ?? [],
+      resolutionOrder:
+        resolutionOrder && resolutionOrder.length > 0
+          ? resolutionOrder.map((entry) => ({ ...entry }))
+          : [],
       sets: {},
       modifiers: {},
     },
@@ -109,7 +112,7 @@ export async function importFromFigma({
     logger.error({ group: 'import', message: (error as Error).message });
   }
 
-  if (resolutionOrder === undefined) {
+  if (!resolutionOrder?.length) {
     for (const group of ['sets', 'modifiers'] as const) {
       for (const name of Object.keys(result.code[group])) {
         result.code.resolutionOrder.push({ $ref: `#/${group}/${name}` });

--- a/packages/cli/src/import/figma/index.ts
+++ b/packages/cli/src/import/figma/index.ts
@@ -6,6 +6,10 @@ import { formatNumber, getFileID } from './lib.js';
 import { getStyles } from './styles.js';
 import { getVariables } from './variables.js';
 
+export interface FigmaResolutionOrderEntry {
+  $ref: string;
+}
+
 export interface importFromFigmaOptions {
   url: string;
   logger: Logger;
@@ -23,6 +27,8 @@ export interface importFromFigmaOptions {
   durationNames?: string;
   /** RegEx for overriding STRING Variable types with cubicBezier tokens */
   cubicBezierNames?: string;
+  /** Explicit Resolver order to preserve. By default, imported groups are listed in discovery order. */
+  resolutionOrder?: readonly FigmaResolutionOrderEntry[];
 }
 
 export interface FigmaOutput {
@@ -43,6 +49,7 @@ export async function importFromFigma({
   numberNames,
   durationNames,
   cubicBezierNames,
+  resolutionOrder,
 }: importFromFigmaOptions): Promise<FigmaOutput> {
   const fileKey = getFileID(url);
   if (!fileKey) {
@@ -55,7 +62,7 @@ export async function importFromFigma({
     code: {
       $schema: 'https://www.designtokens.org/schemas/2025.10/resolver.json',
       version: '2025.10',
-      resolutionOrder: [],
+      resolutionOrder: resolutionOrder?.map((entry) => ({ ...entry })) ?? [],
       sets: {},
       modifiers: {},
     },
@@ -63,7 +70,7 @@ export async function importFromFigma({
 
   try {
     const [styles, vars] = await Promise.all([
-      ...(skipStyles ? [] : [getStyles(fileKey!, { logger })]),
+      ...(skipStyles ? [] : [getStyles(fileKey!, { logger, unpublished })]),
       ...(skipVariables
         ? []
         : [
@@ -98,10 +105,11 @@ export async function importFromFigma({
     logger.error({ group: 'import', message: (error as Error).message });
   }
 
-  // Arbitrarily guess on resolutionOrder
-  for (const group of ['sets', 'modifiers'] as const) {
-    for (const name of Object.keys(result.code[group])) {
-      result.code.resolutionOrder.push({ $ref: `#/${group}/${name}` });
+  if (resolutionOrder === undefined) {
+    for (const group of ['sets', 'modifiers'] as const) {
+      for (const name of Object.keys(result.code[group])) {
+        result.code.resolutionOrder.push({ $ref: `#/${group}/${name}` });
+      }
     }
   }
 

--- a/packages/cli/src/import/figma/index.ts
+++ b/packages/cli/src/import/figma/index.ts
@@ -19,6 +19,10 @@ export interface importFromFigmaOptions {
   fontWeightNames?: string;
   /** RegEx for overriding Variable types with number tokens */
   numberNames?: string;
+  /** RegEx for overriding STRING Variable types with duration tokens */
+  durationNames?: string;
+  /** RegEx for overriding STRING Variable types with cubicBezier tokens */
+  cubicBezierNames?: string;
 }
 
 export interface FigmaOutput {
@@ -37,6 +41,8 @@ export async function importFromFigma({
   fontFamilyNames = '/fontFamily$',
   fontWeightNames = '/fontWeight$',
   numberNames,
+  durationNames,
+  cubicBezierNames,
 }: importFromFigmaOptions): Promise<FigmaOutput> {
   const fileKey = getFileID(url);
   if (!fileKey) {
@@ -65,6 +71,8 @@ export async function importFromFigma({
               logger,
               unpublished,
               matchers: {
+                cubicBezier: cubicBezierNames ? new RegExp(cubicBezierNames) : undefined,
+                duration: durationNames ? new RegExp(durationNames) : undefined,
                 fontFamily: fontFamilyNames ? new RegExp(fontFamilyNames) : undefined,
                 fontWeight: fontWeightNames ? new RegExp(fontWeightNames) : undefined,
                 number: numberNames ? new RegExp(numberNames) : undefined,

--- a/packages/cli/src/import/figma/index.ts
+++ b/packages/cli/src/import/figma/index.ts
@@ -21,8 +21,10 @@ export interface importFromFigmaOptions {
   fontFamilyNames?: string;
   /** RegEx for overriding Variable types with fontWeight tokens */
   fontWeightNames?: string;
-  /** RegEx for overriding Variable types with number tokens */
+  /** @deprecated RegEx for coercing matching primitive Variables with Number(). */
   numberNames?: string;
+  /** RegEx for overriding FLOAT Variable types with number tokens */
+  numberFloatNames?: string;
   /** RegEx for overriding STRING Variable types with duration tokens */
   durationNames?: string;
   /** RegEx for overriding STRING Variable types with cubicBezier tokens */
@@ -47,6 +49,7 @@ export async function importFromFigma({
   fontFamilyNames = '/fontFamily$',
   fontWeightNames = '/fontWeight$',
   numberNames,
+  numberFloatNames,
   durationNames,
   cubicBezierNames,
   resolutionOrder,
@@ -83,6 +86,7 @@ export async function importFromFigma({
                 fontFamily: fontFamilyNames ? new RegExp(fontFamilyNames) : undefined,
                 fontWeight: fontWeightNames ? new RegExp(fontWeightNames) : undefined,
                 number: numberNames ? new RegExp(numberNames) : undefined,
+                numberFloat: numberFloatNames ? new RegExp(numberFloatNames) : undefined,
               },
             }),
           ]),

--- a/packages/cli/src/import/figma/styles.ts
+++ b/packages/cli/src/import/figma/styles.ts
@@ -53,7 +53,6 @@ export async function getStyles(
 
   const fileNodes = await getFileNodes(fileKey, { ids: [...styleNodeIDs], logger });
 
-  result.count += styleNodeIDs.size;
   for (const [id, s] of stylesByID) {
     const styleNode = fileNodes.nodes[id];
     if (!styleNode) {
@@ -144,6 +143,7 @@ export async function getStyles(
           node = node[key];
         }
         node[name] = layoutGrids;
+        result.count++;
         break;
       }
     }
@@ -160,6 +160,7 @@ export async function getStyles(
         node = node[key];
       }
       node[name] = tokenBase;
+      result.count++;
     }
   }
 
@@ -257,109 +258,23 @@ export function textStyle(node: Node): TypographyValue | undefined {
   const typography: TypographyValue = {
     fontFamily: style.fontFamily.split(',').map((family) => family.trim()),
     fontWeight: style.fontWeight!,
-    fontStyle: normalizeFontStyle(style),
     fontSize: { value: style.fontSize!, unit: 'px' },
     letterSpacing: { value: style.letterSpacing || 0, unit: 'px' },
     lineHeight: getLineHeight(style),
   };
 
-  if ('paragraphSpacing' in style && Number.isFinite(style.paragraphSpacing)) {
-    typography.paragraphSpacing = { value: style.paragraphSpacing!, unit: 'px' };
-  }
-  if ('paragraphIndent' in style && Number.isFinite(style.paragraphIndent)) {
-    typography.paragraphIndent = { value: style.paragraphIndent!, unit: 'px' };
-  }
-  if ('listSpacing' in style && Number.isFinite(style.listSpacing)) {
-    typography.listSpacing = { value: style.listSpacing!, unit: 'px' };
-  }
-  applyTextCase(typography, style.textCase);
-  applyTextDecoration(typography, 'textDecoration' in style ? style.textDecoration : undefined);
-
   return typography;
 }
 
-function getLineHeight(style: TypeStyle): TypographyValue['lineHeight'] {
+function getLineHeight(style: TypeStyle): number {
   if (style.lineHeightUnit === 'FONT_SIZE_%' && Number.isFinite(style.lineHeightPercentFontSize)) {
     return style.lineHeightPercentFontSize! / 100;
   }
-  if (Number.isFinite(style.lineHeightPx)) {
-    return { value: style.lineHeightPx!, unit: 'px' };
+  if (Number.isFinite(style.lineHeightPx) && style.fontSize) {
+    return style.lineHeightPx! / style.fontSize;
   }
   if (Number.isFinite(style.lineHeightPercentFontSize)) {
     return style.lineHeightPercentFontSize! / 100;
   }
   return 1;
-}
-
-function normalizeFontStyle(style: TypeStyle): string | undefined {
-  if (style.italic || /italic/i.test(style.fontStyle || '')) {
-    return 'italic';
-  }
-  if (/oblique/i.test(style.fontStyle || '')) {
-    return 'oblique';
-  }
-  return style.fontStyle ? 'normal' : undefined;
-}
-
-function applyTextCase(typography: TypographyValue, textCase: TypeStyle['textCase']): void {
-  switch (textCase) {
-    case 'ORIGINAL': {
-      typography.textTransform = 'none';
-      break;
-    }
-    case 'UPPER': {
-      typography.textTransform = 'uppercase';
-      break;
-    }
-    case 'LOWER': {
-      typography.textTransform = 'lowercase';
-      break;
-    }
-    case 'TITLE': {
-      typography.textTransform = 'capitalize';
-      break;
-    }
-    case 'SMALL_CAPS': {
-      typography.fontVariantCaps = 'small-caps';
-      break;
-    }
-    case 'SMALL_CAPS_FORCED': {
-      typography.fontVariantCaps = 'all-small-caps';
-      break;
-    }
-    case undefined: {
-      break;
-    }
-    default: {
-      const exhaustiveTextCase: never = textCase;
-      throw new TypeError(`Unknown Figma text case: ${exhaustiveTextCase}`);
-    }
-  }
-}
-
-function applyTextDecoration(
-  typography: TypographyValue,
-  textDecoration: TypeStyle['textDecoration'],
-): void {
-  switch (textDecoration) {
-    case 'NONE': {
-      typography.textDecoration = 'none';
-      break;
-    }
-    case 'STRIKETHROUGH': {
-      typography.textDecoration = 'line-through';
-      break;
-    }
-    case 'UNDERLINE': {
-      typography.textDecoration = 'underline';
-      break;
-    }
-    case undefined: {
-      break;
-    }
-    default: {
-      const exhaustiveTextDecoration: never = textDecoration;
-      throw new TypeError(`Unknown Figma text decoration: ${exhaustiveTextDecoration}`);
-    }
-  }
 }

--- a/packages/cli/src/import/figma/styles.ts
+++ b/packages/cli/src/import/figma/styles.ts
@@ -4,11 +4,11 @@ import type {
   Node,
   PublishedStyle,
   Style,
+  TypeStyle,
 } from '@figma/rest-api-spec';
 import type {
   ColorValue,
   DimensionToken,
-  DimensionValue,
   GradientValue,
   Logger,
   NumberToken,
@@ -131,6 +131,7 @@ export async function getStyles(
             message: `Could not parse grid for ${s.name}`,
             continueOnError: true,
           });
+          break;
         }
         // Note: Grids scaffold out multiple sub-components, so we need to “cheat” a little here
         let node = result.code.sets.styles.sources[0];
@@ -148,7 +149,7 @@ export async function getStyles(
     }
 
     // Only place in tree if we got a value for it
-    if (tokenBase.$type !== undefined) {
+    if (tokenBase.$value !== undefined) {
       let node = result.code.sets.styles.sources[0];
       const path = s.name.split('/').map(formatName);
       const name = path.pop()!;
@@ -233,7 +234,7 @@ export function gridStyles(
     }
     values[pattern] = {
       sectionSize: { $type: 'dimension', $value: { value: grid.sectionSize, unit: 'px' } },
-      gutterSize: { $type: 'dimension', $value: { value: grid.sectionSize, unit: 'px' } },
+      gutterSize: { $type: 'dimension', $value: { value: grid.gutterSize, unit: 'px' } },
     };
     if (grid.count > 0) {
       values[pattern].count = { $type: 'number', $value: grid.count };
@@ -248,21 +249,117 @@ export function textStyle(node: Node): TypographyValue | undefined {
     return;
   }
 
-  let lineHeight: string | number | DimensionValue = 1;
-  if ('lineHeightPercentFontSize' in node.style) {
-    lineHeight = node.style.lineHeightPercentFontSize!;
-  } else if ('lineHeightPx' in node.style) {
-    lineHeight = { value: node.style.lineHeightPx!, unit: 'px' };
+  const { style } = node;
+  if (!style.fontFamily || !Number.isFinite(style.fontWeight) || !Number.isFinite(style.fontSize)) {
+    return;
   }
 
-  return {
-    fontFamily: [node.style.fontFamily!],
-    fontWeight: node.style.fontWeight,
-    fontStyle: node.style.fontStyle,
-    fontSize: node.style.fontSize
-      ? { value: node.style.fontSize, unit: 'px' }
-      : { value: 1, unit: 'em' },
-    letterSpacing: { value: node.style.letterSpacing ?? 0, unit: 'px' },
-    lineHeight,
+  const typography: TypographyValue = {
+    fontFamily: style.fontFamily.split(',').map((family) => family.trim()),
+    fontWeight: style.fontWeight!,
+    fontStyle: normalizeFontStyle(style),
+    fontSize: { value: style.fontSize!, unit: 'px' },
+    letterSpacing: { value: style.letterSpacing || 0, unit: 'px' },
+    lineHeight: getLineHeight(style),
   };
+
+  if ('paragraphSpacing' in style && Number.isFinite(style.paragraphSpacing)) {
+    typography.paragraphSpacing = { value: style.paragraphSpacing!, unit: 'px' };
+  }
+  if ('paragraphIndent' in style && Number.isFinite(style.paragraphIndent)) {
+    typography.paragraphIndent = { value: style.paragraphIndent!, unit: 'px' };
+  }
+  if ('listSpacing' in style && Number.isFinite(style.listSpacing)) {
+    typography.listSpacing = { value: style.listSpacing!, unit: 'px' };
+  }
+  applyTextCase(typography, style.textCase);
+  applyTextDecoration(typography, 'textDecoration' in style ? style.textDecoration : undefined);
+
+  return typography;
+}
+
+function getLineHeight(style: TypeStyle): TypographyValue['lineHeight'] {
+  if (style.lineHeightUnit === 'FONT_SIZE_%' && Number.isFinite(style.lineHeightPercentFontSize)) {
+    return style.lineHeightPercentFontSize! / 100;
+  }
+  if (Number.isFinite(style.lineHeightPx)) {
+    return { value: style.lineHeightPx!, unit: 'px' };
+  }
+  if (Number.isFinite(style.lineHeightPercentFontSize)) {
+    return style.lineHeightPercentFontSize! / 100;
+  }
+  return 1;
+}
+
+function normalizeFontStyle(style: TypeStyle): string | undefined {
+  if (style.italic || /italic/i.test(style.fontStyle || '')) {
+    return 'italic';
+  }
+  if (/oblique/i.test(style.fontStyle || '')) {
+    return 'oblique';
+  }
+  return style.fontStyle ? 'normal' : undefined;
+}
+
+function applyTextCase(typography: TypographyValue, textCase: TypeStyle['textCase']): void {
+  switch (textCase) {
+    case 'ORIGINAL': {
+      typography.textTransform = 'none';
+      break;
+    }
+    case 'UPPER': {
+      typography.textTransform = 'uppercase';
+      break;
+    }
+    case 'LOWER': {
+      typography.textTransform = 'lowercase';
+      break;
+    }
+    case 'TITLE': {
+      typography.textTransform = 'capitalize';
+      break;
+    }
+    case 'SMALL_CAPS': {
+      typography.fontVariantCaps = 'small-caps';
+      break;
+    }
+    case 'SMALL_CAPS_FORCED': {
+      typography.fontVariantCaps = 'all-small-caps';
+      break;
+    }
+    case undefined: {
+      break;
+    }
+    default: {
+      const exhaustiveTextCase: never = textCase;
+      throw new TypeError(`Unknown Figma text case: ${exhaustiveTextCase}`);
+    }
+  }
+}
+
+function applyTextDecoration(
+  typography: TypographyValue,
+  textDecoration: TypeStyle['textDecoration'],
+): void {
+  switch (textDecoration) {
+    case 'NONE': {
+      typography.textDecoration = 'none';
+      break;
+    }
+    case 'STRIKETHROUGH': {
+      typography.textDecoration = 'line-through';
+      break;
+    }
+    case 'UNDERLINE': {
+      typography.textDecoration = 'underline';
+      break;
+    }
+    case undefined: {
+      break;
+    }
+    default: {
+      const exhaustiveTextDecoration: never = textDecoration;
+      throw new TypeError(`Unknown Figma text decoration: ${exhaustiveTextDecoration}`);
+    }
+  }
 }

--- a/packages/cli/src/import/figma/variables.ts
+++ b/packages/cli/src/import/figma/variables.ts
@@ -78,31 +78,33 @@ function matches(matcher: RegExp | undefined, value: string): boolean {
   return matcher.test(value);
 }
 
-function getDirectTypeOverride(
+function getDirectTypeOverrides(
   variable: LocalVariable,
   matchers: FigmaVariableMatchers,
-): FigmaVariableTypeOverride | undefined {
+): Set<FigmaVariableTypeOverride> {
+  const overrides = new Set<FigmaVariableTypeOverride>();
   if (variable.resolvedType === 'STRING' && matches(matchers.fontFamily, variable.name)) {
-    return 'fontFamily';
+    overrides.add('fontFamily');
   }
   if (
     (variable.resolvedType === 'FLOAT' || variable.resolvedType === 'STRING') &&
     matches(matchers.fontWeight, variable.name)
   ) {
-    return 'fontWeight';
+    overrides.add('fontWeight');
   }
   if (matches(matchers.number, variable.name)) {
-    return 'legacyNumber';
+    overrides.add('legacyNumber');
   }
   if (variable.resolvedType === 'FLOAT' && matches(matchers.numberFloat, variable.name)) {
-    return 'number';
+    overrides.add('number');
   }
   if (variable.resolvedType === 'STRING' && matches(matchers.duration, variable.name)) {
-    return 'duration';
+    overrides.add('duration');
   }
   if (variable.resolvedType === 'STRING' && matches(matchers.cubicBezier, variable.name)) {
-    return 'cubicBezier';
+    overrides.add('cubicBezier');
   }
+  return overrides;
 }
 
 function parseDuration(value: unknown): DurationValue | undefined {
@@ -155,7 +157,6 @@ function parseCubicBezier(value: unknown): CubicBezierValue | undefined {
 function applyTypeOverride(
   type: FigmaVariableTypeOverride,
   value: unknown,
-  variableName = 'value',
 ): { $type: FigmaVariableTokenType; $value: unknown } | undefined {
   switch (type) {
     case 'cubicBezier': {
@@ -180,9 +181,10 @@ function applyTypeOverride(
     }
     case 'legacyNumber': {
       if (typeof value === 'object') {
-        throw new TypeError(`Can’t coerce ${variableName} into number type.`);
+        return;
       }
-      return { $type: 'number', $value: Number(value) };
+      const number = Number(value);
+      return Number.isFinite(number) ? { $type: 'number', $value: number } : undefined;
     }
     case 'number': {
       return typeof value === 'number' ? { $type: type, $value: value } : undefined;
@@ -243,11 +245,12 @@ function getTypeOverrides(
       }
     }
 
-    const directOverrides = new Set(
-      component
-        .map((componentID) => getDirectTypeOverride(variables[componentID]!, matchers))
-        .filter((override): override is FigmaVariableTypeOverride => override !== undefined),
-    );
+    const directOverrides = new Set<FigmaVariableTypeOverride>();
+    for (const componentID of component) {
+      for (const override of getDirectTypeOverrides(variables[componentID]!, matchers)) {
+        directOverrides.add(override);
+      }
+    }
     if (directOverrides.has('legacyNumber') && directOverrides.has('number')) {
       directOverrides.delete('number');
     }
@@ -267,7 +270,7 @@ function getTypeOverrides(
     for (const componentID of component) {
       const variable = variables[componentID]!;
       for (const value of Object.values(variable.valuesByMode)) {
-        if (getAliasID(value) || applyTypeOverride(typeOverride!, value, variable.name)) {
+        if (getAliasID(value) || applyTypeOverride(typeOverride!, value)) {
           continue;
         }
         logger.warn({
@@ -415,7 +418,7 @@ export async function getVariables(
           continue;
         }
       } else if (typeOverride) {
-        const overriddenToken = applyTypeOverride(typeOverride, value, variable.name);
+        const overriddenToken = applyTypeOverride(typeOverride, value);
         if (overriddenToken) {
           tokenBase.$type = overriddenToken.$type;
           tokenBase.$value = overriddenToken.$value;

--- a/packages/cli/src/import/figma/variables.ts
+++ b/packages/cli/src/import/figma/variables.ts
@@ -15,7 +15,18 @@ export type FigmaVariableTokenType =
   | 'fontWeight'
   | 'number';
 
-export type FigmaVariableMatchers = Partial<Record<FigmaVariableTokenType, RegExp>>;
+export interface FigmaVariableMatchers {
+  cubicBezier?: RegExp;
+  duration?: RegExp;
+  fontFamily?: RegExp;
+  fontWeight?: RegExp;
+  /** @deprecated Coerces any matching primitive value with Number(). */
+  number?: RegExp;
+  /** Overrides only matching FLOAT Variables as number tokens. */
+  numberFloat?: RegExp;
+}
+
+type FigmaVariableTypeOverride = FigmaVariableTokenType | 'legacyNumber';
 
 const FIGMA_TYPE_MAP: Record<VariableResolvedDataType, string> = {
   BOOLEAN: 'boolean',
@@ -38,26 +49,58 @@ function getAliasID(value: unknown): string | undefined {
   return undefined;
 }
 
-function getTypeOverride(
+const FONT_WEIGHT_VALUES = new Set([
+  'thin',
+  'hairline',
+  'extra-light',
+  'ultra-light',
+  'light',
+  'normal',
+  'regular',
+  'book',
+  'medium',
+  'semi-bold',
+  'demi-bold',
+  'bold',
+  'extra-bold',
+  'ultra-bold',
+  'black',
+  'heavy',
+  'extra-black',
+  'ultra-black',
+]);
+
+function matches(matcher: RegExp | undefined, value: string): boolean {
+  if (!matcher) {
+    return false;
+  }
+  matcher.lastIndex = 0;
+  return matcher.test(value);
+}
+
+function getDirectTypeOverride(
   variable: LocalVariable,
   matchers: FigmaVariableMatchers,
-): FigmaVariableTokenType | undefined {
-  if (variable.resolvedType === 'STRING' && matchers.fontFamily?.test(variable.name)) {
+): FigmaVariableTypeOverride | undefined {
+  if (variable.resolvedType === 'STRING' && matches(matchers.fontFamily, variable.name)) {
     return 'fontFamily';
   }
   if (
     (variable.resolvedType === 'FLOAT' || variable.resolvedType === 'STRING') &&
-    matchers.fontWeight?.test(variable.name)
+    matches(matchers.fontWeight, variable.name)
   ) {
     return 'fontWeight';
   }
-  if (variable.resolvedType === 'FLOAT' && matchers.number?.test(variable.name)) {
+  if (matches(matchers.number, variable.name)) {
+    return 'legacyNumber';
+  }
+  if (variable.resolvedType === 'FLOAT' && matches(matchers.numberFloat, variable.name)) {
     return 'number';
   }
-  if (variable.resolvedType === 'STRING' && matchers.duration?.test(variable.name)) {
+  if (variable.resolvedType === 'STRING' && matches(matchers.duration, variable.name)) {
     return 'duration';
   }
-  if (variable.resolvedType === 'STRING' && matchers.cubicBezier?.test(variable.name)) {
+  if (variable.resolvedType === 'STRING' && matches(matchers.cubicBezier, variable.name)) {
     return 'cubicBezier';
   }
 }
@@ -66,7 +109,7 @@ function parseDuration(value: unknown): DurationValue | undefined {
   if (typeof value !== 'string') {
     return;
   }
-  const match = value.match(/^\s*(\d+(?:\.\d+)?|\.\d+)\s*(ms|s)\s*$/i);
+  const match = value.match(/^\s*([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(ms|s)\s*$/i);
   if (!match) {
     return;
   }
@@ -110,8 +153,9 @@ function parseCubicBezier(value: unknown): CubicBezierValue | undefined {
 }
 
 function applyTypeOverride(
-  type: FigmaVariableTokenType,
+  type: FigmaVariableTypeOverride,
   value: unknown,
+  variableName = 'value',
 ): { $type: FigmaVariableTokenType; $value: unknown } | undefined {
   switch (type) {
     case 'cubicBezier': {
@@ -126,7 +170,19 @@ function applyTypeOverride(
       return { $type: type, $value: String(value).split(',') };
     }
     case 'fontWeight': {
-      return { $type: type, $value: value };
+      if (
+        (typeof value === 'number' && Number.isFinite(value) && value >= 1 && value <= 1000) ||
+        (typeof value === 'string' && FONT_WEIGHT_VALUES.has(value))
+      ) {
+        return { $type: type, $value: value };
+      }
+      return;
+    }
+    case 'legacyNumber': {
+      if (typeof value === 'object') {
+        throw new TypeError(`Can’t coerce ${variableName} into number type.`);
+      }
+      return { $type: 'number', $value: Number(value) };
     }
     case 'number': {
       return typeof value === 'number' ? { $type: type, $value: value } : undefined;
@@ -136,6 +192,98 @@ function applyTypeOverride(
       throw new TypeError(`Unknown Figma Variable type override: ${exhaustiveType}`);
     }
   }
+}
+
+function getTokenType(type: FigmaVariableTypeOverride): FigmaVariableTokenType {
+  return type === 'legacyNumber' ? 'number' : type;
+}
+
+function getTypeOverrides(
+  variables: Record<string, LocalVariable>,
+  matchers: FigmaVariableMatchers,
+  logger: Logger,
+): Map<string, FigmaVariableTypeOverride> {
+  const neighbors = new Map<string, Set<string>>();
+  for (const [id, variable] of Object.entries(variables)) {
+    if (!neighbors.has(id)) {
+      neighbors.set(id, new Set());
+    }
+    for (const value of Object.values(variable.valuesByMode)) {
+      const aliasID = getAliasID(value);
+      if (!aliasID || !variables[aliasID]) {
+        continue;
+      }
+      neighbors.get(id)!.add(aliasID);
+      if (!neighbors.has(aliasID)) {
+        neighbors.set(aliasID, new Set());
+      }
+      neighbors.get(aliasID)!.add(id);
+    }
+  }
+
+  const resolvedOverrides = new Map<string, FigmaVariableTypeOverride>();
+  const visited = new Set<string>();
+  for (const id of Object.keys(variables)) {
+    if (visited.has(id)) {
+      continue;
+    }
+    const component: string[] = [];
+    const pending = [id];
+    while (pending.length > 0) {
+      const nextID = pending.pop()!;
+      if (visited.has(nextID)) {
+        continue;
+      }
+      visited.add(nextID);
+      component.push(nextID);
+      for (const neighbor of neighbors.get(nextID) || []) {
+        if (!visited.has(neighbor)) {
+          pending.push(neighbor);
+        }
+      }
+    }
+
+    const directOverrides = new Set(
+      component
+        .map((componentID) => getDirectTypeOverride(variables[componentID]!, matchers))
+        .filter((override): override is FigmaVariableTypeOverride => override !== undefined),
+    );
+    if (directOverrides.has('legacyNumber') && directOverrides.has('number')) {
+      directOverrides.delete('number');
+    }
+    if (directOverrides.size === 0) {
+      continue;
+    }
+    if (directOverrides.size > 1) {
+      logger.warn({
+        group: 'import',
+        message: `Conflicting type overrides in Figma Variable alias chain: ${component.map((componentID) => variables[componentID]!.name).join(', ')}. Preserving Figma types.`,
+      });
+      continue;
+    }
+
+    const [typeOverride] = directOverrides;
+    let canApplyToComponent = true;
+    for (const componentID of component) {
+      const variable = variables[componentID]!;
+      for (const value of Object.values(variable.valuesByMode)) {
+        if (getAliasID(value) || applyTypeOverride(typeOverride!, value, variable.name)) {
+          continue;
+        }
+        logger.warn({
+          group: 'import',
+          message: `Could not convert ${variable.name} to ${getTokenType(typeOverride!)}; preserving its Figma ${variable.resolvedType} type.`,
+        });
+        canApplyToComponent = false;
+      }
+    }
+    if (canApplyToComponent) {
+      for (const componentID of component) {
+        resolvedOverrides.set(componentID, typeOverride!);
+      }
+    }
+  }
+  return resolvedOverrides;
 }
 
 /** /v1/files/:file_key/variables/published | /v1/files/:file_key/variables/local */
@@ -206,6 +354,7 @@ export async function getVariables(
   }
 
   const remoteIDs = new Set<string>();
+  const typeOverrides = getTypeOverrides(finalVariables, matchers, logger);
 
   for (const id of Object.keys(finalVariables)) {
     const variable = finalVariables[id]!;
@@ -223,7 +372,7 @@ export async function getVariables(
       result.code.sets[collectionName] = { sources: [{}] };
     }
 
-    const typeOverride = getTypeOverride(variable, matchers);
+    const typeOverride = typeOverrides.get(id);
 
     for (const [modeID, value] of Object.entries(variable.valuesByMode)) {
       const modeName = modeIDToName[modeID]!;
@@ -257,21 +406,23 @@ export async function getVariables(
       const isAliasOfID = getAliasID(value);
       if (isAliasOfID) {
         if (allVariables[isAliasOfID]) {
-          tokenBase.$type = typeOverride || FIGMA_TYPE_MAP[variable.resolvedType];
+          tokenBase.$type = typeOverride
+            ? getTokenType(typeOverride)
+            : FIGMA_TYPE_MAP[variable.resolvedType];
           tokenBase.$value = `{${allVariables[isAliasOfID].name.split('/').map(formatName).join('.')}}`;
         } else {
           remoteIDs.add(isAliasOfID);
           continue;
         }
       } else if (typeOverride) {
-        const overriddenToken = applyTypeOverride(typeOverride, value);
+        const overriddenToken = applyTypeOverride(typeOverride, value, variable.name);
         if (overriddenToken) {
           tokenBase.$type = overriddenToken.$type;
           tokenBase.$value = overriddenToken.$value;
         } else {
           logger.warn({
             group: 'import',
-            message: `Could not convert ${variable.name} to ${typeOverride}; preserving its Figma ${variable.resolvedType} type.`,
+            message: `Could not convert ${variable.name} to ${getTokenType(typeOverride)}; preserving its Figma ${variable.resolvedType} type.`,
           });
         }
       }

--- a/packages/cli/src/import/figma/variables.ts
+++ b/packages/cli/src/import/figma/variables.ts
@@ -1,7 +1,28 @@
-import type { LocalVariable, LocalVariableCollection, RGBA } from '@figma/rest-api-spec';
-import type { Logger } from '@terrazzo/parser';
+import type {
+  LocalVariable,
+  LocalVariableCollection,
+  RGBA,
+  VariableResolvedDataType,
+} from '@figma/rest-api-spec';
+import type { CubicBezierValue, DurationValue, Logger } from '@terrazzo/parser';
 
 import { formatName, getFileLocalVariables, getFilePublishedVariables } from './lib.js';
+
+export type FigmaVariableTokenType =
+  | 'cubicBezier'
+  | 'duration'
+  | 'fontFamily'
+  | 'fontWeight'
+  | 'number';
+
+export type FigmaVariableMatchers = Partial<Record<FigmaVariableTokenType, RegExp>>;
+
+const FIGMA_TYPE_MAP: Record<VariableResolvedDataType, string> = {
+  BOOLEAN: 'boolean',
+  COLOR: 'color',
+  FLOAT: 'dimension',
+  STRING: 'string',
+};
 
 function getAliasID(value: unknown): string | undefined {
   if (
@@ -17,6 +38,106 @@ function getAliasID(value: unknown): string | undefined {
   return undefined;
 }
 
+function getTypeOverride(
+  variable: LocalVariable,
+  matchers: FigmaVariableMatchers,
+): FigmaVariableTokenType | undefined {
+  if (variable.resolvedType === 'STRING' && matchers.fontFamily?.test(variable.name)) {
+    return 'fontFamily';
+  }
+  if (
+    (variable.resolvedType === 'FLOAT' || variable.resolvedType === 'STRING') &&
+    matchers.fontWeight?.test(variable.name)
+  ) {
+    return 'fontWeight';
+  }
+  if (variable.resolvedType === 'FLOAT' && matchers.number?.test(variable.name)) {
+    return 'number';
+  }
+  if (variable.resolvedType === 'STRING' && matchers.duration?.test(variable.name)) {
+    return 'duration';
+  }
+  if (variable.resolvedType === 'STRING' && matchers.cubicBezier?.test(variable.name)) {
+    return 'cubicBezier';
+  }
+}
+
+function parseDuration(value: unknown): DurationValue | undefined {
+  if (typeof value !== 'string') {
+    return;
+  }
+  const match = value.match(/^\s*(\d+(?:\.\d+)?|\.\d+)\s*(ms|s)\s*$/i);
+  if (!match) {
+    return;
+  }
+  const number = Number(match[1]);
+  if (!Number.isFinite(number)) {
+    return;
+  }
+  return { value: number, unit: match[2]!.toLowerCase() === 's' ? 's' : 'ms' };
+}
+
+function parseCubicBezier(value: unknown): CubicBezierValue | undefined {
+  if (typeof value !== 'string') {
+    return;
+  }
+  const numberPattern = String.raw`[+-]?(?:\d+(?:\.\d+)?|\.\d+)`;
+  const match = value.match(
+    new RegExp(
+      `^\\s*cubic-bezier\\(\\s*(${numberPattern})\\s*,\\s*(${numberPattern})\\s*,\\s*(${numberPattern})\\s*,\\s*(${numberPattern})\\s*\\)\\s*$`,
+      'i',
+    ),
+  );
+  if (!match) {
+    return;
+  }
+  const points: [number, number, number, number] = [
+    Number(match[1]),
+    Number(match[2]),
+    Number(match[3]),
+    Number(match[4]),
+  ];
+  if (
+    points.some((point) => typeof point !== 'number' || !Number.isFinite(point)) ||
+    points[0] < 0 ||
+    points[0] > 1 ||
+    points[2] < 0 ||
+    points[2] > 1
+  ) {
+    return;
+  }
+  return points;
+}
+
+function applyTypeOverride(
+  type: FigmaVariableTokenType,
+  value: unknown,
+): { $type: FigmaVariableTokenType; $value: unknown } | undefined {
+  switch (type) {
+    case 'cubicBezier': {
+      const parsed = parseCubicBezier(value);
+      return parsed ? { $type: type, $value: parsed } : undefined;
+    }
+    case 'duration': {
+      const parsed = parseDuration(value);
+      return parsed ? { $type: type, $value: parsed } : undefined;
+    }
+    case 'fontFamily': {
+      return { $type: type, $value: String(value).split(',') };
+    }
+    case 'fontWeight': {
+      return { $type: type, $value: value };
+    }
+    case 'number': {
+      return typeof value === 'number' ? { $type: type, $value: value } : undefined;
+    }
+    default: {
+      const exhaustiveType: never = type;
+      throw new TypeError(`Unknown Figma Variable type override: ${exhaustiveType}`);
+    }
+  }
+}
+
 /** /v1/files/:file_key/variables/published | /v1/files/:file_key/variables/local */
 export async function getVariables(
   fileKey: string,
@@ -27,7 +148,7 @@ export async function getVariables(
   }: {
     logger: Logger;
     unpublished?: boolean;
-    matchers: Record<'fontFamily' | 'fontWeight' | 'number', RegExp | undefined>;
+    matchers: FigmaVariableMatchers;
   },
 ): Promise<{ count: number; remoteCount: number; code: any }> {
   const result: { count: number; remoteCount: number; code: any } = {
@@ -102,11 +223,7 @@ export async function getVariables(
       result.code.sets[collectionName] = { sources: [{}] };
     }
 
-    const matches =
-      (matchers.fontFamily?.test(variable.name) && 'fontFamily') ||
-      (matchers.fontWeight?.test(variable.name) && 'fontWeight') ||
-      (matchers.number?.test(variable.name) && 'number') ||
-      undefined;
+    const typeOverride = getTypeOverride(variable, matchers);
 
     for (const [modeID, value] of Object.entries(variable.valuesByMode)) {
       const modeName = modeIDToName[modeID]!;
@@ -140,29 +257,25 @@ export async function getVariables(
       const isAliasOfID = getAliasID(value);
       if (isAliasOfID) {
         if (allVariables[isAliasOfID]) {
-          tokenBase.$type =
-            matches ||
-            { COLOR: 'color', BOOLEAN: 'boolean', STRING: 'string', FLOAT: 'dimension' }[
-              variable.resolvedType
-            ];
+          tokenBase.$type = typeOverride || FIGMA_TYPE_MAP[variable.resolvedType];
           tokenBase.$value = `{${allVariables[isAliasOfID].name.split('/').map(formatName).join('.')}}`;
         } else {
           remoteIDs.add(isAliasOfID);
           continue;
         }
-      } else if (matches === 'fontFamily') {
-        tokenBase.$type = 'fontFamily';
-        tokenBase.$value = String(value).split(',');
-      } else if (matches === 'fontWeight') {
-        tokenBase.$type = 'fontWeight';
-        tokenBase.$value = value;
-      } else if (matches === 'number') {
-        if (typeof value === 'object') {
-          throw new TypeError(`Can’t coerce ${variable.name} into number type.`);
+      } else if (typeOverride) {
+        const overriddenToken = applyTypeOverride(typeOverride, value);
+        if (overriddenToken) {
+          tokenBase.$type = overriddenToken.$type;
+          tokenBase.$value = overriddenToken.$value;
+        } else {
+          logger.warn({
+            group: 'import',
+            message: `Could not convert ${variable.name} to ${typeOverride}; preserving its Figma ${variable.resolvedType} type.`,
+          });
         }
-        tokenBase.$type = 'number';
-        tokenBase.$value = Number(value); // fun fact: this coerces booleans correctly
-      } else {
+      }
+      if (tokenBase.$value === undefined) {
         switch (variable.resolvedType) {
           case 'BOOLEAN':
           case 'STRING': {
@@ -180,6 +293,10 @@ export async function getVariables(
             tokenBase.$type = 'color';
             tokenBase.$value = { colorSpace: 'srgb', components: [r, g, b], alpha: a };
             break;
+          }
+          default: {
+            const exhaustiveType: never = variable.resolvedType;
+            throw new TypeError(`Unknown Figma Variable resolved type: ${exhaustiveType}`);
           }
         }
       }

--- a/packages/cli/src/import/index.ts
+++ b/packages/cli/src/import/index.ts
@@ -37,6 +37,10 @@ export async function importCmd({ flags, positionals, logger }: ImportCmdOptions
       });
     }
 
+    const oldFile =
+      flags.output && fsSync.existsSync(flags.output)
+        ? JSON.parse(await fs.readFile(flags.output, 'utf8'))
+        : {};
     const start = performance.now();
     const result = await importFromFigma({
       url: url!,
@@ -49,21 +53,17 @@ export async function importCmd({ flags, positionals, logger }: ImportCmdOptions
       numberNames: flags['number-names'],
       durationNames: flags['duration-names'],
       cubicBezierNames: flags['cubic-bezier-names'],
+      resolutionOrder: oldFile.resolutionOrder,
     });
     const end = performance.now() - start;
 
     if (flags.output) {
-      const oldFile = fsSync.existsSync(flags.output)
-        ? JSON.parse(await fs.readFile(flags.output, 'utf8'))
-        : {};
       // merge with old file, if any
       const code = {
         $schema: result.code.$schema, // Reset $schema
         version: result.code.version, // Reset version
         // Note: it’s important to have resolutionOrder higher up, since sets and modifiers will be a mess
-        resolutionOrder: oldFile.resolutionOrder?.length
-          ? oldFile.resolutionOrder
-          : result.code.resolutionOrder, // Rely on old file, since the Figma file won’t understand resolutionOrder
+        resolutionOrder: result.code.resolutionOrder,
         sets: result.code.sets, // Overwrite old sets
         modifiers: result.code.modifiers, // Overwrite old modifiers
         $defs: oldFile.$defs, // Just in case

--- a/packages/cli/src/import/index.ts
+++ b/packages/cli/src/import/index.ts
@@ -47,6 +47,8 @@ export async function importCmd({ flags, positionals, logger }: ImportCmdOptions
       fontFamilyNames: flags['font-family-names'],
       fontWeightNames: flags['font-weight-names'],
       numberNames: flags['number-names'],
+      durationNames: flags['duration-names'],
+      cubicBezierNames: flags['cubic-bezier-names'],
     });
     const end = performance.now() - start;
 

--- a/packages/cli/src/import/index.ts
+++ b/packages/cli/src/import/index.ts
@@ -51,6 +51,7 @@ export async function importCmd({ flags, positionals, logger }: ImportCmdOptions
       fontFamilyNames: flags['font-family-names'],
       fontWeightNames: flags['font-weight-names'],
       numberNames: flags['number-names'],
+      numberFloatNames: flags['number-float-names'],
       durationNames: flags['duration-names'],
       cubicBezierNames: flags['cubic-bezier-names'],
       resolutionOrder: oldFile.resolutionOrder,

--- a/packages/cli/test/figma-import-options.test.ts
+++ b/packages/cli/test/figma-import-options.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { importFromFigma } from '../src/import/figma/index.js';
+
+const FILE_KEY = 'AaAaAaAaAaAaAaAaAa';
+const FILE_URL = `https://www.figma.com/design/${FILE_KEY}/Import-Options`;
+const STYLE_ID = '1:1';
+const logger = { error() {}, warn() {}, info() {}, success() {} } as never;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('importFromFigma options', () => {
+  it('preserves an explicit resolution order', async () => {
+    const resolutionOrder = [
+      { $ref: '#/modifiers/theme' },
+      { $ref: '#/sets/foundation' },
+      { $ref: '#/sets/styles' },
+    ];
+
+    const result = await importFromFigma({
+      url: FILE_URL,
+      logger,
+      resolutionOrder,
+      skipStyles: true,
+      skipVariables: true,
+    });
+
+    expect(result.code.resolutionOrder).toEqual(resolutionOrder);
+  });
+
+  it.each([
+    {
+      name: 'published',
+      unpublished: false,
+      expectedURL: `https://api.figma.com/v1/files/${FILE_KEY}/styles`,
+      unexpectedURL: `https://api.figma.com/v1/files/${FILE_KEY}`,
+    },
+    {
+      name: 'unpublished',
+      unpublished: true,
+      expectedURL: `https://api.figma.com/v1/files/${FILE_KEY}`,
+      unexpectedURL: `https://api.figma.com/v1/files/${FILE_KEY}/styles`,
+    },
+  ])('uses the $name Styles endpoint', async ({ unpublished, expectedURL, unexpectedURL }) => {
+    vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+    const localStyle = {
+      key: 'local-style-key',
+      name: 'elevation/default',
+      description: '',
+      remote: false,
+      styleType: 'EFFECT',
+    };
+    const publishedStyle = {
+      key: 'published-style-key',
+      file_key: FILE_KEY,
+      node_id: STYLE_ID,
+      style_type: 'EFFECT',
+      name: 'elevation/default',
+      description: '',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      user: {},
+    };
+    const responses: Record<string, object> = {
+      [`https://api.figma.com/v1/files/${FILE_KEY}`]: {
+        styles: { [STYLE_ID]: localStyle },
+      },
+      [`https://api.figma.com/v1/files/${FILE_KEY}/styles`]: {
+        error: false,
+        status: 200,
+        meta: { styles: [publishedStyle] },
+      },
+      [`https://api.figma.com/v1/files/${FILE_KEY}/nodes?ids=${STYLE_ID}`]: {
+        nodes: {
+          [STYLE_ID]: {
+            document: {
+              effects: [
+                {
+                  type: 'DROP_SHADOW',
+                  visible: true,
+                  color: { r: 0, g: 0, b: 0, a: 0.25 },
+                  blendMode: 'NORMAL',
+                  offset: { x: 0, y: 2 },
+                  radius: 4,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const response = responses[input.toString()];
+      return Promise.resolve(Response.json(response));
+    });
+
+    const result = await importFromFigma({
+      url: FILE_URL,
+      logger,
+      unpublished,
+      skipVariables: true,
+    });
+
+    expect(result.styleCount).toBe(1);
+    expect(result.code.sets.styles.sources[0].elevation.default).toEqual(
+      expect.objectContaining({ $type: 'shadow' }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(expectedURL, expect.any(Object));
+    expect(fetchMock).not.toHaveBeenCalledWith(unexpectedURL, expect.any(Object));
+  });
+});

--- a/packages/cli/test/figma-import-options.test.ts
+++ b/packages/cli/test/figma-import-options.test.ts
@@ -31,6 +31,61 @@ describe('importFromFigma options', () => {
     expect(result.code.resolutionOrder).toEqual(resolutionOrder);
   });
 
+  it('regenerates discovery order when explicit resolution order is empty', async () => {
+    vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const responses: Record<string, object> = {
+        [`https://api.figma.com/v1/files/${FILE_KEY}/styles`]: {
+          error: false,
+          status: 200,
+          meta: {
+            styles: [
+              {
+                key: 'published-style-key',
+                file_key: FILE_KEY,
+                node_id: STYLE_ID,
+                style_type: 'EFFECT',
+                name: 'elevation/default',
+                description: '',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+                user: {},
+              },
+            ],
+          },
+        },
+        [`https://api.figma.com/v1/files/${FILE_KEY}/nodes?ids=${STYLE_ID}`]: {
+          nodes: {
+            [STYLE_ID]: {
+              document: {
+                effects: [
+                  {
+                    type: 'DROP_SHADOW',
+                    visible: true,
+                    color: { r: 0, g: 0, b: 0, a: 0.25 },
+                    blendMode: 'NORMAL',
+                    offset: { x: 0, y: 2 },
+                    radius: 4,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      return Promise.resolve(Response.json(responses[input.toString()]));
+    });
+
+    const result = await importFromFigma({
+      url: FILE_URL,
+      logger,
+      resolutionOrder: [],
+      skipVariables: true,
+    });
+
+    expect(result.code.resolutionOrder).toEqual([{ $ref: '#/sets/styles' }]);
+  });
+
   it.each([
     {
       name: 'published',

--- a/packages/cli/test/figma-styles.test.ts
+++ b/packages/cli/test/figma-styles.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
 import { defineConfig, parse } from '@terrazzo/parser';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { effectStyle, getStyles, gridStyles, textStyle } from '../src/import/figma/styles.js';
 

--- a/packages/cli/test/figma-styles.test.ts
+++ b/packages/cli/test/figma-styles.test.ts
@@ -27,7 +27,7 @@ describe('textStyle', () => {
         lineHeightPx: 20,
         lineHeightPercentFontSize: 142.857,
       },
-      expected: { value: 20, unit: 'px' },
+      expected: 20 / 14,
     },
     {
       name: 'font-size percent',
@@ -47,13 +47,13 @@ describe('textStyle', () => {
         lineHeightPx: 24,
         lineHeightPercentFontSize: 150,
       },
-      expected: { value: 24, unit: 'px' },
+      expected: 1.5,
     },
   ])('uses the $name line-height representation', ({ style, expected }) => {
-    expect(textStyle({ style } as never)?.lineHeight).toEqual(expected);
+    expect(textStyle({ style } as never)?.lineHeight).toBeCloseTo(expected);
   });
 
-  it('normalizes CSS typography fields exposed by Figma', () => {
+  it('omits Figma text semantics outside the DTCG typography contract', () => {
     const value = textStyle({
       style: {
         ...baseTextStyle,
@@ -62,6 +62,7 @@ describe('textStyle', () => {
         lineHeightPx: 24,
         paragraphSpacing: 12,
         paragraphIndent: 4,
+        listSpacing: 8,
         textCase: 'UPPER',
         textDecoration: 'STRIKETHROUGH',
       },
@@ -70,49 +71,13 @@ describe('textStyle', () => {
     expect(value).toEqual({
       fontFamily: ['Inter'],
       fontWeight: 400,
-      fontStyle: 'italic',
       fontSize: { value: 16, unit: 'px' },
       letterSpacing: { value: 0, unit: 'px' },
-      lineHeight: { value: 24, unit: 'px' },
-      paragraphSpacing: { value: 12, unit: 'px' },
-      paragraphIndent: { value: 4, unit: 'px' },
-      textTransform: 'uppercase',
-      textDecoration: 'line-through',
+      lineHeight: 1.5,
     });
-  });
-
-  it.each([
-    ['Regular', false, 'normal'],
-    ['Oblique', false, 'oblique'],
-    ['Regular', true, 'italic'],
-  ])('normalizes %s with italic=%s to %s', (fontStyle, italic, expected) => {
-    expect(
-      textStyle({
-        style: {
-          ...baseTextStyle,
-          fontStyle,
-          italic,
-          lineHeightUnit: 'PIXELS',
-          lineHeightPx: 24,
-        },
-      } as never)?.fontStyle,
-    ).toBe(expected);
-  });
-
-  it.each([
-    ['SMALL_CAPS', 'small-caps'],
-    ['SMALL_CAPS_FORCED', 'all-small-caps'],
-  ])('maps Figma %s text case to font variant caps', (textCase, expected) => {
-    expect(
-      textStyle({
-        style: {
-          ...baseTextStyle,
-          lineHeightUnit: 'PIXELS',
-          lineHeightPx: 24,
-          textCase,
-        },
-      } as never)?.fontVariantCaps,
-    ).toBe(expected);
+    expect(Object.keys(value!).toSorted()).toEqual(
+      ['fontFamily', 'fontSize', 'fontWeight', 'letterSpacing', 'lineHeight'].toSorted(),
+    );
   });
 });
 
@@ -218,9 +183,81 @@ describe('getStyles', () => {
     const result = await getStyles(fileKey, { logger: logger as never });
 
     expect(result.code.sets.styles.sources[0]).toEqual({});
+    expect(result.count).toBe(0);
     expect(logger.error).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'Could not parse effect for blur/default' }),
     );
+  });
+
+  it('imports TEXT styles with the exact DTCG 2025.10 typography shape', async () => {
+    const fileKey = 'BbBbBbBbBbBbBbBbBb';
+    const styleID = '2:2';
+    vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const responses: Record<string, object> = {
+        [`https://api.figma.com/v1/files/${fileKey}/styles`]: {
+          error: false,
+          status: 200,
+          meta: {
+            styles: [
+              {
+                key: 'text-key',
+                file_key: fileKey,
+                node_id: styleID,
+                style_type: 'TEXT',
+                name: 'text/body',
+                description: '',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+                user: {},
+              },
+            ],
+          },
+        },
+        [`https://api.figma.com/v1/files/${fileKey}/nodes?ids=${styleID}`]: {
+          nodes: {
+            [styleID]: {
+              document: {
+                style: {
+                  ...baseTextStyle,
+                  fontStyle: 'Italic',
+                  lineHeightUnit: 'PIXELS',
+                  lineHeightPx: 24,
+                  paragraphSpacing: 12,
+                  paragraphIndent: 4,
+                  listSpacing: 8,
+                  textCase: 'UPPER',
+                  textDecoration: 'UNDERLINE',
+                },
+              },
+            },
+          },
+        },
+      };
+      return Promise.resolve(Response.json(responses[input.toString()]));
+    });
+    const logger = {
+      error: vi.fn(),
+      warn() {},
+      info() {},
+      success() {},
+    };
+
+    const result = await getStyles(fileKey, { logger: logger as never });
+    const token = result.code.sets.styles.sources[0].text.body;
+
+    expect(token.$type).toBe('typography');
+    expect(token.$value).toEqual({
+      fontFamily: ['Inter'],
+      fontSize: { value: 16, unit: 'px' },
+      fontWeight: 400,
+      letterSpacing: { value: 0, unit: 'px' },
+      lineHeight: 1.5,
+    });
+    expect(Object.keys(token.$value).toSorted()).toEqual(
+      ['fontFamily', 'fontSize', 'fontWeight', 'letterSpacing', 'lineHeight'].toSorted(),
+    );
+    expect(result.count).toBe(1);
   });
 });
 
@@ -261,6 +298,9 @@ describe('DTCG validation', () => {
       { config: defineConfig({}, { cwd: new URL(import.meta.url) }), skipLint: true },
     );
 
+    expect(Object.keys(typography!).toSorted()).toEqual(
+      ['fontFamily', 'fontSize', 'fontWeight', 'letterSpacing', 'lineHeight'].toSorted(),
+    );
     expect(result.tokens.typography?.$value).toEqual(typography);
     expect(result.tokens.shadow?.$value).toEqual(shadow);
   });

--- a/packages/cli/test/figma-styles.test.ts
+++ b/packages/cli/test/figma-styles.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineConfig, parse } from '@terrazzo/parser';
+
+import { effectStyle, getStyles, gridStyles, textStyle } from '../src/import/figma/styles.js';
+
+const baseTextStyle = {
+  fontFamily: 'Inter',
+  fontStyle: 'Regular',
+  fontWeight: 400,
+  fontSize: 16,
+  letterSpacing: 0,
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('textStyle', () => {
+  it.each([
+    {
+      name: 'pixels',
+      style: {
+        ...baseTextStyle,
+        fontSize: 14,
+        lineHeightUnit: 'PIXELS',
+        lineHeightPx: 20,
+        lineHeightPercentFontSize: 142.857,
+      },
+      expected: { value: 20, unit: 'px' },
+    },
+    {
+      name: 'font-size percent',
+      style: {
+        ...baseTextStyle,
+        lineHeightUnit: 'FONT_SIZE_%',
+        lineHeightPx: 24,
+        lineHeightPercentFontSize: 150,
+      },
+      expected: 1.5,
+    },
+    {
+      name: 'automatic',
+      style: {
+        ...baseTextStyle,
+        lineHeightUnit: 'INTRINSIC_%',
+        lineHeightPx: 24,
+        lineHeightPercentFontSize: 150,
+      },
+      expected: { value: 24, unit: 'px' },
+    },
+  ])('uses the $name line-height representation', ({ style, expected }) => {
+    expect(textStyle({ style } as never)?.lineHeight).toEqual(expected);
+  });
+
+  it('normalizes CSS typography fields exposed by Figma', () => {
+    const value = textStyle({
+      style: {
+        ...baseTextStyle,
+        fontStyle: 'Semi Bold Italic',
+        lineHeightUnit: 'PIXELS',
+        lineHeightPx: 24,
+        paragraphSpacing: 12,
+        paragraphIndent: 4,
+        textCase: 'UPPER',
+        textDecoration: 'STRIKETHROUGH',
+      },
+    } as never);
+
+    expect(value).toEqual({
+      fontFamily: ['Inter'],
+      fontWeight: 400,
+      fontStyle: 'italic',
+      fontSize: { value: 16, unit: 'px' },
+      letterSpacing: { value: 0, unit: 'px' },
+      lineHeight: { value: 24, unit: 'px' },
+      paragraphSpacing: { value: 12, unit: 'px' },
+      paragraphIndent: { value: 4, unit: 'px' },
+      textTransform: 'uppercase',
+      textDecoration: 'line-through',
+    });
+  });
+
+  it.each([
+    ['Regular', false, 'normal'],
+    ['Oblique', false, 'oblique'],
+    ['Regular', true, 'italic'],
+  ])('normalizes %s with italic=%s to %s', (fontStyle, italic, expected) => {
+    expect(
+      textStyle({
+        style: {
+          ...baseTextStyle,
+          fontStyle,
+          italic,
+          lineHeightUnit: 'PIXELS',
+          lineHeightPx: 24,
+        },
+      } as never)?.fontStyle,
+    ).toBe(expected);
+  });
+
+  it.each([
+    ['SMALL_CAPS', 'small-caps'],
+    ['SMALL_CAPS_FORCED', 'all-small-caps'],
+  ])('maps Figma %s text case to font variant caps', (textCase, expected) => {
+    expect(
+      textStyle({
+        style: {
+          ...baseTextStyle,
+          lineHeightUnit: 'PIXELS',
+          lineHeightPx: 24,
+          textCase,
+        },
+      } as never)?.fontVariantCaps,
+    ).toBe(expected);
+  });
+});
+
+describe('effectStyle', () => {
+  it('keeps shadow effects and ignores valueless blur effects', () => {
+    const value = effectStyle({
+      effects: [
+        { type: 'LAYER_BLUR', visible: true, radius: 8 },
+        {
+          type: 'DROP_SHADOW',
+          visible: true,
+          color: { r: 0, g: 0, b: 0, a: 0.2 },
+          blendMode: 'NORMAL',
+          offset: { x: 0, y: 2 },
+          radius: 4,
+        },
+      ],
+    } as never);
+
+    expect(value).toHaveLength(1);
+    expect(value?.[0]).toEqual(
+      expect.objectContaining({
+        inset: false,
+        blur: { value: 4, unit: 'px' },
+      }),
+    );
+    expect(
+      effectStyle({ effects: [{ type: 'LAYER_BLUR', visible: true, radius: 8 }] } as never),
+    ).toBe(undefined);
+  });
+});
+
+describe('gridStyles', () => {
+  it('keeps section and gutter sizes distinct', () => {
+    const value = gridStyles({
+      layoutGrids: [
+        {
+          pattern: 'COLUMNS',
+          sectionSize: 4,
+          gutterSize: 20,
+          visible: true,
+          color: { r: 1, g: 0, b: 0, a: 0.1 },
+          alignment: 'STRETCH',
+          offset: 0,
+          count: 5,
+        },
+      ],
+    } as never);
+
+    expect(value?.columns).toEqual({
+      sectionSize: { $type: 'dimension', $value: { value: 4, unit: 'px' } },
+      gutterSize: { $type: 'dimension', $value: { value: 20, unit: 'px' } },
+      count: { $type: 'number', $value: 5 },
+    });
+  });
+});
+
+describe('getStyles', () => {
+  it('omits styles that cannot produce a value', async () => {
+    const fileKey = 'AaAaAaAaAaAaAaAaAa';
+    const styleID = '1:1';
+    vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const responses: Record<string, object> = {
+        [`https://api.figma.com/v1/files/${fileKey}/styles`]: {
+          error: false,
+          status: 200,
+          meta: {
+            styles: [
+              {
+                key: 'blur-key',
+                file_key: fileKey,
+                node_id: styleID,
+                style_type: 'EFFECT',
+                name: 'blur/default',
+                description: '',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+                user: {},
+              },
+            ],
+          },
+        },
+        [`https://api.figma.com/v1/files/${fileKey}/nodes?ids=${styleID}`]: {
+          nodes: {
+            [styleID]: {
+              document: {
+                effects: [{ type: 'LAYER_BLUR', visible: true, radius: 8 }],
+              },
+            },
+          },
+        },
+      };
+      return Promise.resolve(Response.json(responses[input.toString()]));
+    });
+    const logger = {
+      error: vi.fn(),
+      warn() {},
+      info() {},
+      success() {},
+    };
+
+    const result = await getStyles(fileKey, { logger: logger as never });
+
+    expect(result.code.sets.styles.sources[0]).toEqual({});
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Could not parse effect for blur/default' }),
+    );
+  });
+});
+
+describe('DTCG validation', () => {
+  it('produces parser-valid typography and shadow tokens', async () => {
+    const typography = textStyle({
+      style: {
+        ...baseTextStyle,
+        fontStyle: 'Italic',
+        lineHeightUnit: 'FONT_SIZE_%',
+        lineHeightPercentFontSize: 150,
+        paragraphSpacing: 12,
+        textCase: 'UPPER',
+        textDecoration: 'UNDERLINE',
+      },
+    } as never);
+    const shadow = effectStyle({
+      effects: [
+        {
+          type: 'DROP_SHADOW',
+          visible: true,
+          color: { r: 0, g: 0, b: 0, a: 0.2 },
+          blendMode: 'NORMAL',
+          offset: { x: 0, y: 2 },
+          radius: 4,
+        },
+      ],
+    } as never);
+
+    const result = await parse(
+      {
+        filename: new URL('./figma-styles.tokens.json', import.meta.url),
+        src: {
+          typography: { $type: 'typography', $value: typography },
+          shadow: { $type: 'shadow', $value: shadow },
+        },
+      },
+      { config: defineConfig({}, { cwd: new URL(import.meta.url) }), skipLint: true },
+    );
+
+    expect(result.tokens.typography?.$value).toEqual(typography);
+    expect(result.tokens.shadow?.$value).toEqual(shadow);
+  });
+});

--- a/packages/cli/test/figma-variables.test.ts
+++ b/packages/cli/test/figma-variables.test.ts
@@ -191,7 +191,7 @@ describe('getVariables', () => {
     });
   });
 
-  it('applies number name matching only to FLOAT variables and aliases', async () => {
+  it('offers FLOAT-only number matching without changing legacy coercion', async () => {
     const floatCollectionID = 'VariableCollectionId:float';
     const stringCollectionID = 'VariableCollectionId:string';
     const booleanCollectionID = 'VariableCollectionId:boolean';
@@ -284,7 +284,7 @@ describe('getVariables', () => {
       matchers: {
         fontFamily: undefined,
         fontWeight: undefined,
-        number: /^Layer\//,
+        numberFloat: /^Layer\//,
       },
     });
 
@@ -299,11 +299,34 @@ describe('getVariables', () => {
     expect(result.code.sets.boolean.sources[0].layer.order).toEqual(
       expect.objectContaining({ $type: 'boolean', $value: true }),
     );
+
+    const legacyResult = await getVariables(FILE_KEY, {
+      logger: { error() {}, warn() {}, info() {}, success() {} } as never,
+      matchers: {
+        number: /^Layer\//,
+      },
+    });
+
+    expect(legacyResult.code.sets.float.sources[0].layer).toEqual({
+      order: expect.objectContaining({ $type: 'number', $value: 42 }),
+      orderAlias: expect.objectContaining({ $type: 'number', $value: '{layer.order}' }),
+    });
+    expect(legacyResult.code.sets.string.sources[0].layer).toEqual({
+      order: expect.objectContaining({ $type: 'number', $value: 42 }),
+      orderAlias: expect.objectContaining({ $type: 'number', $value: '{layer.order}' }),
+    });
+    expect(legacyResult.code.sets.boolean.sources[0].layer.order).toEqual(
+      expect.objectContaining({ $type: 'number', $value: 1 }),
+    );
   });
 
   it('maps valid duration and cubic-bezier strings without coercing incompatible values', async () => {
     const collectionID = 'VariableCollectionId:motion';
     const durationID = 'VariableID:duration';
+    const negativeDurationID = 'VariableID:negative-duration';
+    const positiveDurationID = 'VariableID:positive-duration';
+    const decimalDurationID = 'VariableID:decimal-duration';
+    const invalidDurationID = 'VariableID:invalid-duration';
     const numericDurationID = 'VariableID:numeric-duration';
     const easingID = 'VariableID:easing';
     const invalidEasingID = 'VariableID:invalid-easing';
@@ -314,6 +337,42 @@ describe('getVariables', () => {
         variableCollectionId: collectionID,
         resolvedType: 'STRING',
         valuesByMode: { [MODE_ID]: '150ms' },
+        description: '',
+        codeSyntax: {},
+      },
+      [negativeDurationID]: {
+        id: negativeDurationID,
+        name: 'Motion/duration negative',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: '-150ms' },
+        description: '',
+        codeSyntax: {},
+      },
+      [positiveDurationID]: {
+        id: positiveDurationID,
+        name: 'Motion/duration positive',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: '+0.2s' },
+        description: '',
+        codeSyntax: {},
+      },
+      [decimalDurationID]: {
+        id: decimalDurationID,
+        name: 'Motion/duration decimal',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: '.5ms' },
+        description: '',
+        codeSyntax: {},
+      },
+      [invalidDurationID]: {
+        id: invalidDurationID,
+        name: 'Motion/duration invalid',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: '1e3ms' },
         description: '',
         codeSyntax: {},
       },
@@ -385,6 +444,22 @@ describe('getVariables', () => {
         $type: 'duration',
         $value: { value: 150, unit: 'ms' },
       }),
+      durationNegative: expect.objectContaining({
+        $type: 'duration',
+        $value: { value: -150, unit: 'ms' },
+      }),
+      durationPositive: expect.objectContaining({
+        $type: 'duration',
+        $value: { value: 0.2, unit: 's' },
+      }),
+      durationDecimal: expect.objectContaining({
+        $type: 'duration',
+        $value: { value: 0.5, unit: 'ms' },
+      }),
+      durationInvalid: expect.objectContaining({
+        $type: 'string',
+        $value: '1e3ms',
+      }),
       durationNumeric: expect.objectContaining({
         $type: 'dimension',
         $value: { value: 150, unit: 'px' },
@@ -398,5 +473,237 @@ describe('getVariables', () => {
         $value: 'ease-in',
       }),
     });
+  });
+
+  it('propagates overrides through mismatched-name multi-hop aliases with cycle safety', async () => {
+    const collectionID = 'VariableCollectionId:aliases';
+    const chains = [
+      {
+        key: 'duration',
+        resolvedType: 'STRING',
+        value: '-25ms',
+        expectedType: 'duration',
+      },
+      {
+        key: 'cubicBezier',
+        resolvedType: 'STRING',
+        value: 'cubic-bezier(0.1, 0.2, 0.3, 1)',
+        expectedType: 'cubicBezier',
+      },
+      {
+        key: 'fontFamily',
+        resolvedType: 'STRING',
+        value: 'Inter, Arial',
+        expectedType: 'fontFamily',
+      },
+      {
+        key: 'fontWeight',
+        resolvedType: 'FLOAT',
+        value: 500,
+        expectedType: 'fontWeight',
+      },
+      {
+        key: 'number',
+        resolvedType: 'FLOAT',
+        value: 4,
+        expectedType: 'number',
+      },
+    ];
+    const variables: Record<string, object> = {};
+    for (const chain of chains) {
+      const sourceID = `VariableID:${chain.key}-source`;
+      const middleID = `VariableID:${chain.key}-middle`;
+      const targetID = `VariableID:${chain.key}-target`;
+      variables[sourceID] = {
+        id: sourceID,
+        name: `${chain.key}/source`,
+        variableCollectionId: collectionID,
+        resolvedType: chain.resolvedType,
+        valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: middleID } },
+        description: '',
+        codeSyntax: {},
+      };
+      variables[middleID] = {
+        id: middleID,
+        name: `${chain.key}/different middle name`,
+        variableCollectionId: collectionID,
+        resolvedType: chain.resolvedType,
+        valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: targetID } },
+        description: '',
+        codeSyntax: {},
+      };
+      variables[targetID] = {
+        id: targetID,
+        name: `${chain.key}/raw target`,
+        variableCollectionId: collectionID,
+        resolvedType: chain.resolvedType,
+        valuesByMode: { [MODE_ID]: chain.value },
+        description: '',
+        codeSyntax: {},
+      };
+    }
+    const cycleSourceID = 'VariableID:cycle-source';
+    const cycleTargetID = 'VariableID:cycle-target';
+    variables[cycleSourceID] = {
+      id: cycleSourceID,
+      name: 'cycle/source',
+      variableCollectionId: collectionID,
+      resolvedType: 'STRING',
+      valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: cycleTargetID } },
+      description: '',
+      codeSyntax: {},
+    };
+    variables[cycleTargetID] = {
+      id: cycleTargetID,
+      name: 'cycle/different target',
+      variableCollectionId: collectionID,
+      resolvedType: 'STRING',
+      valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: cycleSourceID } },
+      description: '',
+      codeSyntax: {},
+    };
+    mockVariableResponses({
+      local: {
+        status: 200,
+        error: false,
+        meta: {
+          variableCollections: {
+            [collectionID]: {
+              defaultModeId: MODE_ID,
+              id: collectionID,
+              name: 'aliases',
+              remote: false,
+              modes: [{ modeId: MODE_ID, name: 'default' }],
+              hiddenFromPublishing: false,
+            },
+          },
+          variables,
+        },
+      },
+      published: {
+        status: 200,
+        error: false,
+        meta: {
+          variables: Object.fromEntries(Object.keys(variables).map((id) => [id, { id }])),
+        },
+      },
+    });
+
+    const result = await getVariables(FILE_KEY, {
+      logger: { error() {}, warn() {}, info() {}, success() {} } as never,
+      matchers: {
+        duration: /^(?:duration|cycle)\/source$/,
+        cubicBezier: /^cubicBezier\/source$/,
+        fontFamily: /^fontFamily\/source$/,
+        fontWeight: /^fontWeight\/source$/,
+        numberFloat: /^number\/source$/,
+      },
+    });
+
+    for (const { key, expectedType } of chains) {
+      const group = result.code.sets.aliases.sources[0][key];
+      expect(group.source.$type).toBe(expectedType);
+      expect(group.differentMiddleName.$type).toBe(expectedType);
+      expect(group.rawTarget.$type).toBe(expectedType);
+    }
+    expect(result.code.sets.aliases.sources[0].cycle.source.$type).toBe('duration');
+    expect(result.code.sets.aliases.sources[0].cycle.differentTarget.$type).toBe('duration');
+  });
+
+  it('accepts only DTCG fontWeight values and preserves invalid values', async () => {
+    const collectionID = 'VariableCollectionId:font-weight';
+    const values = [
+      ['minimum', 'FLOAT', 1],
+      ['maximum', 'FLOAT', 1000],
+      ['too low', 'FLOAT', 0],
+      ['too high', 'FLOAT', 1001],
+      ['allowed string', 'STRING', 'semi-bold'],
+      ['invalid string', 'STRING', 'Semi Bold'],
+      ['numeric string', 'STRING', '400'],
+    ] as const;
+    const variables: Record<string, object> = Object.fromEntries(
+      values.map(([name, resolvedType, value]) => {
+        const id = `VariableID:font-weight-${name}`;
+        return [
+          id,
+          {
+            id,
+            name: `weight/${name}`,
+            variableCollectionId: collectionID,
+            resolvedType,
+            valuesByMode: { [MODE_ID]: value },
+            description: '',
+            codeSyntax: {},
+          },
+        ];
+      }),
+    );
+    const invalidAliasID = 'VariableID:font-weight-invalid-alias';
+    variables[invalidAliasID] = {
+      id: invalidAliasID,
+      name: 'weight/invalid alias',
+      variableCollectionId: collectionID,
+      resolvedType: 'STRING',
+      valuesByMode: {
+        [MODE_ID]: { type: 'VARIABLE_ALIAS', id: 'VariableID:font-weight-invalid string' },
+      },
+      description: '',
+      codeSyntax: {},
+    };
+    mockVariableResponses({
+      local: {
+        status: 200,
+        error: false,
+        meta: {
+          variableCollections: {
+            [collectionID]: {
+              defaultModeId: MODE_ID,
+              id: collectionID,
+              name: 'font weights',
+              remote: false,
+              modes: [{ modeId: MODE_ID, name: 'default' }],
+              hiddenFromPublishing: false,
+            },
+          },
+          variables,
+        },
+      },
+      published: {
+        status: 200,
+        error: false,
+        meta: {
+          variables: Object.fromEntries(Object.keys(variables).map((id) => [id, { id }])),
+        },
+      },
+    });
+    const logger = { error() {}, warn: vi.fn(), info() {}, success() {} };
+
+    const result = await getVariables(FILE_KEY, {
+      logger: logger as never,
+      matchers: { fontWeight: /^weight\// },
+    });
+    const weights = result.code.sets.fontWeights.sources[0].weight;
+
+    expect(weights.minimum).toEqual(expect.objectContaining({ $type: 'fontWeight', $value: 1 }));
+    expect(weights.maximum).toEqual(expect.objectContaining({ $type: 'fontWeight', $value: 1000 }));
+    expect(weights.allowedString).toEqual(
+      expect.objectContaining({ $type: 'fontWeight', $value: 'semi-bold' }),
+    );
+    expect(weights.tooLow).toEqual(
+      expect.objectContaining({ $type: 'dimension', $value: { value: 0, unit: 'px' } }),
+    );
+    expect(weights.tooHigh).toEqual(
+      expect.objectContaining({ $type: 'dimension', $value: { value: 1001, unit: 'px' } }),
+    );
+    expect(weights.invalidString).toEqual(
+      expect.objectContaining({ $type: 'string', $value: 'Semi Bold' }),
+    );
+    expect(weights.numericString).toEqual(
+      expect.objectContaining({ $type: 'string', $value: '400' }),
+    );
+    expect(weights.invalidAlias).toEqual(
+      expect.objectContaining({ $type: 'string', $value: '{weight.invalidString}' }),
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/cli/test/figma-variables.test.ts
+++ b/packages/cli/test/figma-variables.test.ts
@@ -304,6 +304,7 @@ describe('getVariables', () => {
       logger: { error() {}, warn() {}, info() {}, success() {} } as never,
       matchers: {
         number: /^Layer\//,
+        numberFloat: /^Layer\//,
       },
     });
 
@@ -317,6 +318,207 @@ describe('getVariables', () => {
     });
     expect(legacyResult.code.sets.boolean.sources[0].layer.order).toEqual(
       expect.objectContaining({ $type: 'number', $value: 1 }),
+    );
+  });
+
+  it('limits legacy number coercion to finite alias-component values', async () => {
+    const collectionID = 'VariableCollectionId:legacy-numbers';
+    const cases = [
+      {
+        key: 'string',
+        resolvedType: 'STRING',
+        value: '42',
+        expectedType: 'number',
+        expectedValue: 42,
+      },
+      {
+        key: 'boolean',
+        resolvedType: 'BOOLEAN',
+        value: false,
+        expectedType: 'number',
+        expectedValue: 0,
+      },
+      {
+        key: 'invalid',
+        resolvedType: 'STRING',
+        value: 'not-a-number',
+        expectedType: 'string',
+        expectedValue: 'not-a-number',
+      },
+      {
+        key: 'nonfinite',
+        resolvedType: 'STRING',
+        value: '1e999',
+        expectedType: 'string',
+        expectedValue: '1e999',
+      },
+    ];
+    const variables: Record<string, object> = {};
+    for (const testCase of cases) {
+      const leafID = `VariableID:legacy-${testCase.key}-leaf`;
+      const aliasID = `VariableID:legacy-${testCase.key}-alias`;
+      variables[leafID] = {
+        id: leafID,
+        name: `Legacy/${testCase.key} raw`,
+        variableCollectionId: collectionID,
+        resolvedType: testCase.resolvedType,
+        valuesByMode: { [MODE_ID]: testCase.value },
+        description: '',
+        codeSyntax: {},
+      };
+      variables[aliasID] = {
+        id: aliasID,
+        name: `Legacy/${testCase.key} alias`,
+        variableCollectionId: collectionID,
+        resolvedType: testCase.resolvedType,
+        valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: leafID } },
+        description: '',
+        codeSyntax: {},
+      };
+    }
+    mockVariableResponses({
+      local: {
+        status: 200,
+        error: false,
+        meta: {
+          variableCollections: {
+            [collectionID]: {
+              defaultModeId: MODE_ID,
+              id: collectionID,
+              name: 'legacy',
+              remote: false,
+              modes: [{ modeId: MODE_ID, name: 'default' }],
+              hiddenFromPublishing: false,
+            },
+          },
+          variables,
+        },
+      },
+      published: {
+        status: 200,
+        error: false,
+        meta: {
+          variables: Object.fromEntries(Object.keys(variables).map((id) => [id, { id }])),
+        },
+      },
+    });
+    const logger = { error() {}, warn: vi.fn(), info() {}, success() {} };
+
+    const result = await getVariables(FILE_KEY, {
+      logger: logger as never,
+      matchers: { number: /^Legacy\// },
+    });
+    const legacy = result.code.sets.legacy.sources[0].legacy;
+
+    for (const testCase of cases) {
+      const rawName = `${testCase.key}Raw`;
+      const aliasName = `${testCase.key}Alias`;
+      expect(legacy[rawName]).toEqual(
+        expect.objectContaining({
+          $type: testCase.expectedType,
+          $value: testCase.expectedValue,
+        }),
+      );
+      expect(legacy[aliasName]).toEqual(
+        expect.objectContaining({
+          $type: testCase.expectedType,
+          $value: `{legacy.${rawName}}`,
+        }),
+      );
+    }
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(result.code)).not.toContain('"$value":null');
+  });
+
+  it('preserves mixed-mode alias components when direct matchers conflict', async () => {
+    const collectionID = 'VariableCollectionId:conflicts';
+    const alternateModeID = '1:2';
+    const sourceID = 'VariableID:conflict-source';
+    const targetID = 'VariableID:conflict-target';
+    const variables = {
+      [sourceID]: {
+        id: sourceID,
+        name: 'Motion/fontFamily',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: {
+          [MODE_ID]: '150ms',
+          [alternateModeID]: { type: 'VARIABLE_ALIAS', id: targetID },
+        },
+        description: '',
+        codeSyntax: {},
+      },
+      [targetID]: {
+        id: targetID,
+        name: 'Motion/raw value',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: {
+          [MODE_ID]: '150ms',
+          [alternateModeID]: '200ms',
+        },
+        description: '',
+        codeSyntax: {},
+      },
+    };
+    mockVariableResponses({
+      local: {
+        status: 200,
+        error: false,
+        meta: {
+          variableCollections: {
+            [collectionID]: {
+              defaultModeId: MODE_ID,
+              id: collectionID,
+              name: 'conflicts',
+              remote: false,
+              modes: [
+                { modeId: MODE_ID, name: 'default' },
+                { modeId: alternateModeID, name: 'alternate' },
+              ],
+              hiddenFromPublishing: false,
+            },
+          },
+          variables,
+        },
+      },
+      published: {
+        status: 200,
+        error: false,
+        meta: {
+          variables: Object.fromEntries(Object.keys(variables).map((id) => [id, { id }])),
+        },
+      },
+    });
+    const logger = { error() {}, warn: vi.fn(), info() {}, success() {} };
+
+    const result = await getVariables(FILE_KEY, {
+      logger: logger as never,
+      matchers: {
+        fontFamily: /\/fontFamily$/,
+        duration: /fontFamily$/,
+        number: /fontFamily$/,
+        cubicBezier: /fontFamily$/,
+      },
+    });
+    const defaultTokens = result.code.modifiers.conflicts.contexts.default[0].motion;
+    const alternateTokens = result.code.modifiers.conflicts.contexts.alternate[0].motion;
+
+    expect(defaultTokens.fontFamily).toEqual(
+      expect.objectContaining({ $type: 'string', $value: '150ms' }),
+    );
+    expect(defaultTokens.rawValue).toEqual(
+      expect.objectContaining({ $type: 'string', $value: '150ms' }),
+    );
+    expect(alternateTokens.fontFamily).toEqual(
+      expect.objectContaining({ $type: 'string', $value: '{motion.rawValue}' }),
+    );
+    expect(alternateTokens.rawValue).toEqual(
+      expect.objectContaining({ $type: 'string', $value: '200ms' }),
+    );
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Conflicting type overrides') }),
     );
   });
 

--- a/packages/cli/test/figma-variables.test.ts
+++ b/packages/cli/test/figma-variables.test.ts
@@ -92,21 +92,29 @@ const publishedVariablesResponse = {
   },
 };
 
+function mockVariableResponses({
+  local = localVariablesResponse,
+  published = publishedVariablesResponse,
+}: {
+  local?: object;
+  published?: object;
+} = {}) {
+  globalThis.fetch = vi.fn().mockImplementation((url: string) =>
+    Promise.resolve(
+      new Response(
+        {
+          [`https://api.figma.com/v1/files/${FILE_KEY}/variables/local`]: JSON.stringify(local),
+          [`https://api.figma.com/v1/files/${FILE_KEY}/variables/published`]:
+            JSON.stringify(published),
+        }[url],
+      ),
+    ),
+  );
+}
+
 describe('getVariables', () => {
   beforeEach(() => {
-    globalThis.fetch = vi.fn().mockImplementation((url: string) =>
-      Promise.resolve(
-        new Response(
-          {
-            [`https://api.figma.com/v1/files/${FILE_KEY}/variables/local`]:
-              JSON.stringify(localVariablesResponse),
-            [`https://api.figma.com/v1/files/${FILE_KEY}/variables/published`]: JSON.stringify(
-              publishedVariablesResponse,
-            ),
-          }[url],
-        ),
-      ),
-    );
+    mockVariableResponses();
   });
 
   afterAll(() => {
@@ -180,6 +188,215 @@ describe('getVariables', () => {
           $value: '{foundation.hidden}',
         }),
       },
+    });
+  });
+
+  it('applies number name matching only to FLOAT variables and aliases', async () => {
+    const floatCollectionID = 'VariableCollectionId:float';
+    const stringCollectionID = 'VariableCollectionId:string';
+    const booleanCollectionID = 'VariableCollectionId:boolean';
+    const floatID = 'VariableID:float';
+    const floatAliasID = 'VariableID:float-alias';
+    const stringID = 'VariableID:string';
+    const stringAliasID = 'VariableID:string-alias';
+    const booleanID = 'VariableID:boolean';
+    const variableCollections = Object.fromEntries(
+      [
+        [floatCollectionID, 'float'],
+        [stringCollectionID, 'string'],
+        [booleanCollectionID, 'boolean'],
+      ].map(([id, name]) => [
+        id,
+        {
+          defaultModeId: MODE_ID,
+          id,
+          name,
+          remote: false,
+          modes: [{ modeId: MODE_ID, name: 'default' }],
+          hiddenFromPublishing: false,
+        },
+      ]),
+    );
+    const variables = {
+      [floatID]: {
+        id: floatID,
+        name: 'Layer/order',
+        variableCollectionId: floatCollectionID,
+        resolvedType: 'FLOAT',
+        valuesByMode: { [MODE_ID]: 42 },
+        description: '',
+        codeSyntax: {},
+      },
+      [floatAliasID]: {
+        id: floatAliasID,
+        name: 'Layer/order alias',
+        variableCollectionId: floatCollectionID,
+        resolvedType: 'FLOAT',
+        valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: floatID } },
+        description: '',
+        codeSyntax: {},
+      },
+      [stringID]: {
+        id: stringID,
+        name: 'Layer/order',
+        variableCollectionId: stringCollectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: '42' },
+        description: '',
+        codeSyntax: {},
+      },
+      [stringAliasID]: {
+        id: stringAliasID,
+        name: 'Layer/order alias',
+        variableCollectionId: stringCollectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: { type: 'VARIABLE_ALIAS', id: stringID } },
+        description: '',
+        codeSyntax: {},
+      },
+      [booleanID]: {
+        id: booleanID,
+        name: 'Layer/order',
+        variableCollectionId: booleanCollectionID,
+        resolvedType: 'BOOLEAN',
+        valuesByMode: { [MODE_ID]: true },
+        description: '',
+        codeSyntax: {},
+      },
+    };
+    mockVariableResponses({
+      local: {
+        status: 200,
+        error: false,
+        meta: { variableCollections, variables },
+      },
+      published: {
+        status: 200,
+        error: false,
+        meta: {
+          variables: Object.fromEntries(Object.keys(variables).map((id) => [id, { id }])),
+        },
+      },
+    });
+
+    const result = await getVariables(FILE_KEY, {
+      logger: { error() {}, warn() {}, info() {}, success() {} } as never,
+      matchers: {
+        fontFamily: undefined,
+        fontWeight: undefined,
+        number: /^Layer\//,
+      },
+    });
+
+    expect(result.code.sets.float.sources[0].layer).toEqual({
+      order: expect.objectContaining({ $type: 'number', $value: 42 }),
+      orderAlias: expect.objectContaining({ $type: 'number', $value: '{layer.order}' }),
+    });
+    expect(result.code.sets.string.sources[0].layer).toEqual({
+      order: expect.objectContaining({ $type: 'string', $value: '42' }),
+      orderAlias: expect.objectContaining({ $type: 'string', $value: '{layer.order}' }),
+    });
+    expect(result.code.sets.boolean.sources[0].layer.order).toEqual(
+      expect.objectContaining({ $type: 'boolean', $value: true }),
+    );
+  });
+
+  it('maps valid duration and cubic-bezier strings without coercing incompatible values', async () => {
+    const collectionID = 'VariableCollectionId:motion';
+    const durationID = 'VariableID:duration';
+    const numericDurationID = 'VariableID:numeric-duration';
+    const easingID = 'VariableID:easing';
+    const invalidEasingID = 'VariableID:invalid-easing';
+    const variables = {
+      [durationID]: {
+        id: durationID,
+        name: 'Motion/duration',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: '150ms' },
+        description: '',
+        codeSyntax: {},
+      },
+      [numericDurationID]: {
+        id: numericDurationID,
+        name: 'Motion/duration numeric',
+        variableCollectionId: collectionID,
+        resolvedType: 'FLOAT',
+        valuesByMode: { [MODE_ID]: 150 },
+        description: '',
+        codeSyntax: {},
+      },
+      [easingID]: {
+        id: easingID,
+        name: 'Motion/easing',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: 'cubic-bezier(0.25, 0.1, 0.25, 1)' },
+        description: '',
+        codeSyntax: {},
+      },
+      [invalidEasingID]: {
+        id: invalidEasingID,
+        name: 'Motion/invalid easing',
+        variableCollectionId: collectionID,
+        resolvedType: 'STRING',
+        valuesByMode: { [MODE_ID]: 'ease-in' },
+        description: '',
+        codeSyntax: {},
+      },
+    };
+    mockVariableResponses({
+      local: {
+        status: 200,
+        error: false,
+        meta: {
+          variableCollections: {
+            [collectionID]: {
+              defaultModeId: MODE_ID,
+              id: collectionID,
+              name: 'motion',
+              remote: false,
+              modes: [{ modeId: MODE_ID, name: 'default' }],
+              hiddenFromPublishing: false,
+            },
+          },
+          variables,
+        },
+      },
+      published: {
+        status: 200,
+        error: false,
+        meta: {
+          variables: Object.fromEntries(Object.keys(variables).map((id) => [id, { id }])),
+        },
+      },
+    });
+
+    const result = await getVariables(FILE_KEY, {
+      logger: { error() {}, warn() {}, info() {}, success() {} } as never,
+      matchers: {
+        cubicBezier: /easing/i,
+        duration: /duration/i,
+      },
+    });
+
+    expect(result.code.sets.motion.sources[0].motion).toEqual({
+      duration: expect.objectContaining({
+        $type: 'duration',
+        $value: { value: 150, unit: 'ms' },
+      }),
+      durationNumeric: expect.objectContaining({
+        $type: 'dimension',
+        $value: { value: 150, unit: 'px' },
+      }),
+      easing: expect.objectContaining({
+        $type: 'cubicBezier',
+        $value: [0.25, 0.1, 0.25, 1],
+      }),
+      invalidEasing: expect.objectContaining({
+        $type: 'string',
+        $value: 'ease-in',
+      }),
     });
   });
 });

--- a/packages/cli/test/fixtures/import-figma/import-default.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-default.want.json
@@ -100,7 +100,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -109,7 +109,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 7.142857074737549
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -128,7 +131,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -137,7 +140,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 6.25
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -238,7 +244,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 20,
+                    "value": 0,
                     "unit": "px"
                   }
                 },
@@ -258,7 +264,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 4,
+                    "value": 20,
                     "unit": "px"
                   }
                 },
@@ -278,7 +284,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 10,
+                    "value": 0,
                     "unit": "px"
                   }
                 }

--- a/packages/cli/test/fixtures/import-figma/import-default.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-default.want.json
@@ -100,7 +100,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -109,10 +108,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.07142857142857142
                 },
                 "$extensions": {
                   "figma.com": {
@@ -131,7 +127,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -140,10 +135,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.0625
                 },
                 "$extensions": {
                   "figma.com": {

--- a/packages/cli/test/fixtures/import-figma/import-name-matchers.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-name-matchers.want.json
@@ -100,7 +100,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -109,7 +109,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 7.142857074737549
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -128,7 +131,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -137,7 +140,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 6.25
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -238,7 +244,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 20,
+                    "value": 0,
                     "unit": "px"
                   }
                 },
@@ -258,7 +264,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 4,
+                    "value": 20,
                     "unit": "px"
                   }
                 },
@@ -278,7 +284,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 10,
+                    "value": 0,
                     "unit": "px"
                   }
                 }

--- a/packages/cli/test/fixtures/import-figma/import-name-matchers.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-name-matchers.want.json
@@ -100,7 +100,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -109,10 +108,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.07142857142857142
                 },
                 "$extensions": {
                   "figma.com": {
@@ -131,7 +127,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -140,10 +135,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.0625
                 },
                 "$extensions": {
                   "figma.com": {

--- a/packages/cli/test/fixtures/import-figma/import-styles.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-styles.want.json
@@ -64,7 +64,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -73,7 +73,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 7.142857074737549
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -92,7 +95,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -101,7 +104,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 6.25
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -202,7 +208,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 20,
+                    "value": 0,
                     "unit": "px"
                   }
                 },
@@ -222,7 +228,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 4,
+                    "value": 20,
                     "unit": "px"
                   }
                 },
@@ -242,7 +248,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 10,
+                    "value": 0,
                     "unit": "px"
                   }
                 }

--- a/packages/cli/test/fixtures/import-figma/import-styles.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-styles.want.json
@@ -64,7 +64,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -73,10 +72,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.07142857142857142
                 },
                 "$extensions": {
                   "figma.com": {
@@ -95,7 +91,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -104,10 +99,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.0625
                 },
                 "$extensions": {
                   "figma.com": {

--- a/packages/cli/test/fixtures/import-figma/import-unpublished.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-unpublished.want.json
@@ -100,7 +100,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -109,7 +109,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 7.142857074737549
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -128,7 +131,7 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "Regular",
+                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -137,7 +140,10 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": 6.25
+                  "lineHeight": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 },
                 "$extensions": {
                   "figma.com": {
@@ -238,7 +244,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 20,
+                    "value": 0,
                     "unit": "px"
                   }
                 },
@@ -258,7 +264,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 4,
+                    "value": 20,
                     "unit": "px"
                   }
                 },
@@ -278,7 +284,7 @@
                 "gutterSize": {
                   "$type": "dimension",
                   "$value": {
-                    "value": 10,
+                    "value": 0,
                     "unit": "px"
                   }
                 }

--- a/packages/cli/test/fixtures/import-figma/import-unpublished.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-unpublished.want.json
@@ -100,7 +100,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 14,
                     "unit": "px"
@@ -109,10 +108,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.07142857142857142
                 },
                 "$extensions": {
                   "figma.com": {
@@ -131,7 +127,6 @@
                     "SF Pro"
                   ],
                   "fontWeight": 400,
-                  "fontStyle": "normal",
                   "fontSize": {
                     "value": 16,
                     "unit": "px"
@@ -140,10 +135,7 @@
                     "value": 0,
                     "unit": "px"
                   },
-                  "lineHeight": {
-                    "value": 1,
-                    "unit": "px"
-                  }
+                  "lineHeight": 0.0625
                 },
                 "$extensions": {
                   "figma.com": {

--- a/packages/cli/test/help.test.ts
+++ b/packages/cli/test/help.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { helpCmd } from '../src/help.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('helpCmd', () => {
+  it('documents the Figma variable override flags', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    helpCmd();
+
+    expect(log).toHaveBeenCalledOnce();
+    const output = log.mock.calls[0]?.[0];
+    expect(output).toContain('--font-family-names [regex]');
+    expect(output).toContain('--font-weight-names [regex]');
+    expect(output).toContain('--number-names [regex]');
+    expect(output).toContain('--duration-names [regex]');
+    expect(output).toContain('--cubic-bezier-names [regex]');
+  });
+});

--- a/packages/cli/test/help.test.ts
+++ b/packages/cli/test/help.test.ts
@@ -17,7 +17,10 @@ describe('helpCmd', () => {
     expect(output).toContain('--font-family-names [regex]');
     expect(output).toContain('--font-weight-names [regex]');
     expect(output).toContain('--number-names [regex]');
+    expect(output).toContain('Deprecated: coerce matching primitives as number');
+    expect(output).toContain('--number-float-names [regex]');
     expect(output).toContain('--duration-names [regex]');
     expect(output).toContain('--cubic-bezier-names [regex]');
+    expect(output).toContain('Include unpublished Styles and Variables');
   });
 });

--- a/packages/cli/test/import.test.ts
+++ b/packages/cli/test/import.test.ts
@@ -21,6 +21,21 @@ describe('import', () => {
       'utf8',
     );
     const FIGMA_GET_STYLES = await fs.readFile(new URL('./get-styles.json', cwd), 'utf8');
+    const FIGMA_GET_FILE = JSON.stringify({
+      styles: Object.fromEntries(
+        JSON.parse(FIGMA_GET_STYLES).meta.styles.map(
+          ({
+            node_id,
+            style_type,
+            ...style
+          }: {
+            node_id: string;
+            style_type: string;
+            [key: string]: unknown;
+          }) => [node_id, { ...style, styleType: style_type }],
+        ),
+      ),
+    });
 
     beforeEach(() => {
       vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
@@ -30,6 +45,7 @@ describe('import', () => {
         Promise.resolve(
           new Response(
             {
+              [`https://api.figma.com/v1/files/${FILE_KEY}`]: FIGMA_GET_FILE,
               [`https://api.figma.com/v1/files/${FILE_KEY}/nodes`]: FIGMA_GET_FILE_NODES,
               [`https://api.figma.com/v1/files/${FILE_KEY}/styles`]: FIGMA_GET_STYLES,
               [`https://api.figma.com/v1/files/${FILE_KEY}/variables/local`]:

--- a/packages/cli/test/import.test.ts
+++ b/packages/cli/test/import.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { Logger } from '@terrazzo/parser';
@@ -120,6 +122,26 @@ describe('import', () => {
       await expect(
         await fs.readFile(new URL('./import-unpublished.actual.json', cwd), 'utf8'),
       ).toMatchFileSnapshot(fileURLToPath(new URL('./import-unpublished.want.json', cwd)));
+    });
+
+    it('regenerates an empty resolutionOrder when updating an output file', async () => {
+      const tempDirectory = await fs.mkdtemp(join(tmpdir(), 'terrazzo-figma-import-'));
+      const output = join(tempDirectory, 'resolver.json');
+      await fs.writeFile(output, JSON.stringify({ resolutionOrder: [] }));
+
+      try {
+        await importCmd({
+          logger: new Logger(),
+          positionals: ['import', `https://www.figma.com/design/${FILE_KEY}/My-File?node-id=1:1`],
+          flags: { output },
+        });
+
+        const result = JSON.parse(await fs.readFile(output, 'utf8'));
+        expect(result.resolutionOrder.length).toBeGreaterThan(0);
+        expect(result.resolutionOrder[0]).toEqual({ $ref: '#/sets/styles' });
+      } finally {
+        await fs.rm(tempDirectory, { recursive: true });
+      }
     });
 
     it('--font-family-names, --font-weight-names, --number-names', async () => {

--- a/packages/parser/src/lint/plugin-core/rules/valid-font-weight.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-font-weight.ts
@@ -13,7 +13,7 @@ const ERROR_STYLE = 'ERROR_STYLE';
 export interface RuleFontWeightOptions {
   /**
    * Enforce either:
-   * - "numbers" (0-999)
+   * - "numbers" (1-1000)
    * - "names" ("light", "medium", "bold", etc.)
    */
   style?: 'numbers' | 'names';
@@ -22,11 +22,11 @@ export interface RuleFontWeightOptions {
 const rule: LintRule<typeof ERROR | typeof ERROR_STYLE, RuleFontWeightOptions> = {
   meta: {
     messages: {
-      [ERROR]: `Must either be a valid number (0 - 999) or a valid font weight: ${new Intl.ListFormat('en-us', { type: 'disjunction' }).format(Object.keys(FONT_WEIGHTS))}.`,
+      [ERROR]: `Must either be a valid number (1 - 1000) or a valid font weight: ${new Intl.ListFormat('en-us', { type: 'disjunction' }).format(Object.keys(FONT_WEIGHTS))}.`,
       [ERROR_STYLE]: 'Expected style {{ style }}, received {{ value }}.',
     },
     docs: {
-      description: 'Require number tokens to follow the format.',
+      description: 'Require font weight tokens to use DTCG-valid values.',
       url: docsLink(VALID_FONT_WEIGHT),
     },
   },
@@ -50,7 +50,11 @@ const rule: LintRule<typeof ERROR | typeof ERROR_STYLE, RuleFontWeightOptions> =
           break;
         }
         case 'typography': {
-          if (typeof t.originalValue.$value === 'object' && t.originalValue.$value.fontWeight) {
+          if (
+            typeof t.originalValue.$value === 'object' &&
+            t.originalValue.$value &&
+            'fontWeight' in t.originalValue.$value
+          ) {
             if (t.partialAliasOf?.fontWeight) {
               continue;
             }
@@ -95,7 +99,7 @@ function validateFontWeight(
   } else if (typeof value === 'number') {
     if (options.style === 'names') {
       report({ messageId: ERROR_STYLE, data: { style: 'names', value }, node, filename });
-    } else if (!(value >= 0 && value < 1000)) {
+    } else if (!(value >= 1 && value <= 1000)) {
       report({ messageId: ERROR, node, filename });
     }
   } else {

--- a/packages/parser/test/font-weight.test.ts
+++ b/packages/parser/test/font-weight.test.ts
@@ -5,12 +5,18 @@ import { DEFAULT_FILENAME, parserTest, type Test } from './test-utils.js';
 describe('8.4 Font Weight', () => {
   const tests: Test[] = [
     [
-      'valid: number',
+      'valid: number boundaries',
       {
         given: [
-          { filename: DEFAULT_FILENAME, src: { bold: { $type: 'fontWeight', $value: 700 } } },
+          {
+            filename: DEFAULT_FILENAME,
+            src: {
+              minimum: { $type: 'fontWeight', $value: 1 },
+              maximum: { $type: 'fontWeight', $value: 1000 },
+            },
+          },
         ],
-        want: { tokens: { bold: { $value: 700 } } },
+        want: { tokens: { minimum: { $value: 1 }, maximum: { $value: 1000 } } },
       },
     ],
     [
@@ -78,7 +84,7 @@ describe('8.4 Font Weight', () => {
           },
         ],
         want: {
-          error: `lint:core/valid-font-weight: Must either be a valid number (0 - 999) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
+          error: `lint:core/valid-font-weight: Must either be a valid number (1 - 1000) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
 
   2 |   "thinnish": {
   3 |     "$type": "fontWeight",
@@ -92,17 +98,37 @@ lint:lint: 1 error`,
       },
     ],
     [
-      'invalid: number out of range',
+      'invalid: number below lower boundary',
       {
         given: [
-          { filename: DEFAULT_FILENAME, src: { kakarot: { $type: 'fontWeight', $value: 9001 } } },
+          { filename: DEFAULT_FILENAME, src: { weight: { $type: 'fontWeight', $value: 0 } } },
         ],
         want: {
-          error: `lint:core/valid-font-weight: Must either be a valid number (0 - 999) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
+          error: `lint:core/valid-font-weight: Must either be a valid number (1 - 1000) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
 
-  2 |   "kakarot": {
+  2 |   "weight": {
   3 |     "$type": "fontWeight",
-> 4 |     "$value": 9001
+> 4 |     "$value": 0
+    |               ^
+  5 |   }
+  6 | }
+
+lint:lint: 1 error`,
+        },
+      },
+    ],
+    [
+      'invalid: number above upper boundary',
+      {
+        given: [
+          { filename: DEFAULT_FILENAME, src: { weight: { $type: 'fontWeight', $value: 1001 } } },
+        ],
+        want: {
+          error: `lint:core/valid-font-weight: Must either be a valid number (1 - 1000) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
+
+  2 |   "weight": {
+  3 |     "$type": "fontWeight",
+> 4 |     "$value": 1001
     |               ^
   5 |   }
   6 | }

--- a/www/src/pages/docs/guides/import-from-figma.md
+++ b/www/src/pages/docs/guides/import-from-figma.md
@@ -138,14 +138,14 @@ npx tz import [file] \
 The flags are RegEx patterns, so passing in a string will return any match. You can also use slashes to get more specific with token targets. Matching is constrained by the Figma Variable’s resolved type:
 
 - `--number-float-names` overrides only `FLOAT` Variables. `STRING` and `BOOLEAN` Variables with the same name remain their original type.
-- `--number-names` is deprecated but retains its historical behavior for compatibility: matching primitive `FLOAT`, `STRING`, and `BOOLEAN` values are coerced with JavaScript’s `Number()` function.
+- `--number-names` is deprecated but retains its historical behavior for compatibility: matching primitive `FLOAT`, `STRING`, and `BOOLEAN` values are coerced with JavaScript’s `Number()` function when the result is finite. Invalid or non-finite results remain their original Figma type and value. If both number flags match a `FLOAT` Variable, legacy `--number-names` behavior wins explicitly.
 - `--font-family-names`, `--duration-names`, and `--cubic-bezier-names` only override `STRING` Variables.
 - `--font-weight-names` accepts `FLOAT` and `STRING` Variables for backward compatibility.
 - Font weights must be numbers from 1 through 1000 or a DTCG font-weight keyword such as `normal`, `semi-bold`, or `bold`. Invalid matches remain their original Figma type and value.
 - Duration values must use `ms` or `s` units, such as `150ms`, `-0.2s`, or `+.5ms`.
 - Cubic Bézier values must use CSS `cubic-bezier(x1, y1, x2, y2)` syntax. The first and third control points must be between 0 and 1.
 
-Type overrides propagate through alias chains, even when only one differently named Variable matches. This keeps aliases and their targets on the same token type. Values that match a name but can’t be parsed remain their original Figma type and value.
+Type overrides propagate through alias chains, even when only one differently named Variable matches. This keeps aliases and their targets on the same token type. Values that match a name but can’t be parsed remain their original Figma type and value. If incompatible matcher flags overlap on one Variable or anywhere in an alias chain, Terrazzo warns and preserves the Figma types for the entire chain.
 
 Generic `STRING` and `BOOLEAN` Variables are retained for compatibility, but those token types are outside the strict DTCG 2025.10 type enum. A resolver containing them is therefore not guaranteed to pass strict DTCG schema validation unless they are mapped to standard types or removed.
 

--- a/www/src/pages/docs/guides/import-from-figma.md
+++ b/www/src/pages/docs/guides/import-from-figma.md
@@ -75,6 +75,8 @@ Since Figma Styles & Variables don’t map 1:1 with DTCG token types, these are 
 | Variable `STRING`  | [string](/docs/reference/tokens/#string) (⚠️ non-standard type)                                                                                                         |
 | Variable `BOOLEAN` | [boolean](/docs/reference/tokens/#boolean) (⚠️ non-standard type)                                                                                                       |
 
+Text styles preserve pixel or font-size-relative line height according to Figma’s declared unit. Font styles are normalized to CSS-compatible `normal`, `italic`, or `oblique` values, and supported paragraph spacing, indentation, text case, and decoration fields are included. Styles that don’t contain a usable token value, such as an effect style containing only blur effects, are omitted.
+
 #### Grid type
 
 The Grid type is a little special—since it’s a complex concept, it’s represented by a group instead:
@@ -120,18 +122,28 @@ The Grid type is a little special—since it’s a complex concept, it’s repre
 
 The group will only show the `grid`, `rows`, or `columns` subgroups if they appear in the style. If a style has duplicates of the same type, only the first type will be exported.
 
-#### String and Boolean types
+#### Variable type overrides
 
-DTCG does not allow string types, but these are a dominant typeof Figma Variable, especially in typography. In order to override certain Variables by name, pass in `--[type]-names` flags:
+DTCG does not allow string types, but these are a dominant type of Figma Variable, especially in typography. To override certain Variables by name, pass `--[type]-names` flags:
 
 ```sh
 npx tz import [file] \
-    --font-family-names ".*/(family|fontName}$" \
+    --font-family-names ".*/(family|fontName)$" \
     --font-weight-names ".*/weight$" \
-    --number-names ".*/lineHeight$"
+    --number-names ".*/lineHeight$" \
+    --duration-names ".*/duration$" \
+    --cubic-bezier-names ".*/easing$"
 ```
 
-The flags are RegEx patterns, so passing in a string will return any match. You can also use slashes to get more specific with token targets.
+The flags are RegEx patterns, so passing in a string will return any match. You can also use slashes to get more specific with token targets. Matching is constrained by the Figma Variable’s resolved type:
+
+- `--number-names` only overrides `FLOAT` Variables. `STRING` and `BOOLEAN` Variables with the same name remain their original type.
+- `--font-family-names`, `--duration-names`, and `--cubic-bezier-names` only override `STRING` Variables.
+- `--font-weight-names` accepts `FLOAT` and `STRING` Variables for backward compatibility.
+- Duration values must use `ms` or `s` units, such as `150ms` or `0.2s`.
+- Cubic Bézier values must use CSS `cubic-bezier(x1, y1, x2, y2)` syntax. The first and third control points must be between 0 and 1.
+
+Values that match a name but can’t be parsed remain their original Figma type and value.
 
 ### Libraries
 
@@ -142,6 +154,8 @@ npx tz import [file] --unpublished
 ```
 
 If the file has nothing published, it will grab Styles and Variables in the file regardless of the `--unpublished` flag.
+
+When updating an existing resolver through `--output`, Terrazzo preserves its explicit `resolutionOrder`. New resolver files use the imported source order.
 
 ### CLI Flags
 
@@ -156,3 +170,5 @@ You can add all the following flags to `tz import`:
 | `--font-family-names [regex]`  | Import these names as [fontFamily](/docs/reference/tokens/#font-family) tokens. Accepts RegEx. (default: `/fontFamily$`) |
 | `--font-weight-names [regex]`  | Import these names as [fontWeight](/docs/reference/tokens/#font-weight) tokens. Accepts RegEx. (default: `/fontWeight$`) |
 | `--number-names [regex]`       | Import these names as [number](/docs/reference/tokens/#number) tokens. Accepts RegEx. (default: undefined)               |
+| `--duration-names [regex]`     | Import matching string names as [duration](/docs/reference/tokens/#duration) tokens. Accepts RegEx.                      |
+| `--cubic-bezier-names [regex]` | Import matching string names as [cubicBezier](/docs/reference/tokens/#cubic-bezier) tokens. Accepts RegEx.               |

--- a/www/src/pages/docs/guides/import-from-figma.md
+++ b/www/src/pages/docs/guides/import-from-figma.md
@@ -75,7 +75,7 @@ Since Figma Styles & Variables don’t map 1:1 with DTCG token types, these are 
 | Variable `STRING`  | [string](/docs/reference/tokens/#string) (⚠️ non-standard type)                                                                                                         |
 | Variable `BOOLEAN` | [boolean](/docs/reference/tokens/#boolean) (⚠️ non-standard type)                                                                                                       |
 
-Text styles preserve pixel or font-size-relative line height according to Figma’s declared unit. Font styles are normalized to CSS-compatible `normal`, `italic`, or `oblique` values, and supported paragraph spacing, indentation, text case, and decoration fields are included. Styles that don’t contain a usable token value, such as an effect style containing only blur effects, are omitted.
+Text style `$value` objects contain only the five fields allowed and required by the DTCG 2025.10 typography schema: `fontFamily`, `fontSize`, `fontWeight`, `letterSpacing`, and `lineHeight`. Pixel line heights are converted to a font-size multiplier. Figma’s font style, paragraph and list spacing, indentation, text case, and decoration fields are deliberately omitted because the DTCG schema rejects additional typography properties; they are not preserved as extensions until Terrazzo defines a stable extension contract for them. Styles that don’t contain a usable token value, such as an effect style containing only blur effects, are omitted and excluded from the imported Style count.
 
 #### Grid type
 
@@ -144,6 +144,8 @@ The flags are RegEx patterns, so passing in a string will return any match. You 
 - Cubic Bézier values must use CSS `cubic-bezier(x1, y1, x2, y2)` syntax. The first and third control points must be between 0 and 1.
 
 Values that match a name but can’t be parsed remain their original Figma type and value.
+
+Generic `STRING` and `BOOLEAN` Variables are retained for compatibility, but those token types are outside the strict DTCG 2025.10 type enum. A resolver containing them is therefore not guaranteed to pass strict DTCG schema validation unless they are mapped to standard types or removed.
 
 ### Libraries
 

--- a/www/src/pages/docs/guides/import-from-figma.md
+++ b/www/src/pages/docs/guides/import-from-figma.md
@@ -130,20 +130,22 @@ DTCG does not allow string types, but these are a dominant type of Figma Variabl
 npx tz import [file] \
     --font-family-names ".*/(family|fontName)$" \
     --font-weight-names ".*/weight$" \
-    --number-names ".*/lineHeight$" \
+    --number-float-names ".*/lineHeight$" \
     --duration-names ".*/duration$" \
     --cubic-bezier-names ".*/easing$"
 ```
 
 The flags are RegEx patterns, so passing in a string will return any match. You can also use slashes to get more specific with token targets. Matching is constrained by the Figma Variable’s resolved type:
 
-- `--number-names` only overrides `FLOAT` Variables. `STRING` and `BOOLEAN` Variables with the same name remain their original type.
+- `--number-float-names` overrides only `FLOAT` Variables. `STRING` and `BOOLEAN` Variables with the same name remain their original type.
+- `--number-names` is deprecated but retains its historical behavior for compatibility: matching primitive `FLOAT`, `STRING`, and `BOOLEAN` values are coerced with JavaScript’s `Number()` function.
 - `--font-family-names`, `--duration-names`, and `--cubic-bezier-names` only override `STRING` Variables.
 - `--font-weight-names` accepts `FLOAT` and `STRING` Variables for backward compatibility.
-- Duration values must use `ms` or `s` units, such as `150ms` or `0.2s`.
+- Font weights must be numbers from 1 through 1000 or a DTCG font-weight keyword such as `normal`, `semi-bold`, or `bold`. Invalid matches remain their original Figma type and value.
+- Duration values must use `ms` or `s` units, such as `150ms`, `-0.2s`, or `+.5ms`.
 - Cubic Bézier values must use CSS `cubic-bezier(x1, y1, x2, y2)` syntax. The first and third control points must be between 0 and 1.
 
-Values that match a name but can’t be parsed remain their original Figma type and value.
+Type overrides propagate through alias chains, even when only one differently named Variable matches. This keeps aliases and their targets on the same token type. Values that match a name but can’t be parsed remain their original Figma type and value.
 
 Generic `STRING` and `BOOLEAN` Variables are retained for compatibility, but those token types are outside the strict DTCG 2025.10 type enum. A resolver containing them is therefore not guaranteed to pass strict DTCG schema validation unless they are mapped to standard types or removed.
 
@@ -155,7 +157,7 @@ If the Figma file has a [Published Library](https://help.figma.com/hc/en-us/arti
 npx tz import [file] --unpublished
 ```
 
-If the file has nothing published, it will grab Styles and Variables in the file regardless of the `--unpublished` flag.
+Without `--unpublished`, Terrazzo imports only Styles and Variables returned by Figma’s published-library endpoints. It does not fall back to local unpublished Styles or Variables when nothing is published.
 
 When updating an existing resolver through `--output`, Terrazzo preserves its explicit `resolutionOrder`. New resolver files use the imported source order.
 
@@ -171,6 +173,7 @@ You can add all the following flags to `tz import`:
 | `--skip-variables`             | Don’t import Variables from this file (required if not on the Enterprise Plan).                                          |
 | `--font-family-names [regex]`  | Import these names as [fontFamily](/docs/reference/tokens/#font-family) tokens. Accepts RegEx. (default: `/fontFamily$`) |
 | `--font-weight-names [regex]`  | Import these names as [fontWeight](/docs/reference/tokens/#font-weight) tokens. Accepts RegEx. (default: `/fontWeight$`) |
-| `--number-names [regex]`       | Import these names as [number](/docs/reference/tokens/#number) tokens. Accepts RegEx. (default: undefined)               |
+| `--number-names [regex]`       | Deprecated compatibility option. Coerce matching primitive values as [number](/docs/reference/tokens/#number) tokens.    |
+| `--number-float-names [regex]` | Import matching `FLOAT` names as [number](/docs/reference/tokens/#number) tokens. Accepts RegEx.                         |
 | `--duration-names [regex]`     | Import matching string names as [duration](/docs/reference/tokens/#duration) tokens. Accepts RegEx.                      |
 | `--cubic-bezier-names [regex]` | Import matching string names as [cubicBezier](/docs/reference/tokens/#cubic-bezier) tokens. Accepts RegEx.               |

--- a/www/src/pages/docs/reference/tokens.md
+++ b/www/src/pages/docs/reference/tokens.md
@@ -162,12 +162,12 @@ A font weight as defined in [DTCG 8.4](https://www.designtokens.org/tr/2025.10/f
 | Property       | Type     | Description                                                                                                                           |
 | :------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------ |
 | `$type`        | `string` | **Required.** `"fontWeight"`                                                                                                          |
-| `$value`       | `number` | **Required.** Either a font weight number `1` (lightest) –`999` (heaviest), or an [approved alias](#aliases) of a font weight number. |
+| `$value`       | `number` | **Required.** Either a font weight number `1` (lightest)–`1000` (heaviest), or an [approved alias](#aliases) of a font weight number. |
 | `$description` | `string` | (Optional) A description of this token and its intended usage.                                                                        |
 
 ### Aliases
 
-A font weight can be a number from `1` (lightest) – `999` (heaviest), but the following string keywords may also be used (and _only_ the following words):
+A font weight can be a number from `1` (lightest)–`1000` (heaviest), but the following string keywords may also be used (and _only_ the following words):
 
 | Weight | Alias                        |
 | :----- | :--------------------------- |


### PR DESCRIPTION
## Summary

- make Figma variable type overrides resolved-type-safe and consistent across alias chains while preserving deprecated number coercion
- add duration/cubic Bézier mappings, published/unpublished style handling, and explicit resolver-order preservation
- emit DTCG-valid typography/effect/grid styles and align font-weight validation with DTCG 2025.10

## Test plan

- `pnpm --filter @terrazzo/cli test` (44 tests)
- `pnpm --filter @terrazzo/parser test` (271 passed, 1 skipped)
- `pnpm --filter @terrazzo/cli lint`
- `pnpm --filter @terrazzo/parser lint`
- CLI/parser package builds and attw validation
- docs lint/build, Storybook build, repository format, and changeset validation

Made with [Cursor](https://cursor.com)