### PR TITLE
feat(resolver): Add extra methods for token set operations

### DIFF
--- a/.changeset/sharp-eagles-tickle.md
+++ b/.changeset/sharp-eagles-tickle.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/parser": minor
+---
+
+Add extra methods for token set operations

--- a/packages/parser/src/resolver/create-resolver.ts
+++ b/packages/parser/src/resolver/create-resolver.ts
@@ -1,0 +1,287 @@
+import { toMomoa } from '../lib/momoa.js';
+import { destructiveMerge, getPermutationID } from '../lib/resolver-utils.js';
+import { processTokens } from '../parse/process.js';
+import type {
+  CreateResolverOptions,
+  Resolver,
+  ResolverApplicationOptions,
+  ResolverInput,
+  ResolverSourceNormalized,
+  ResolveTokensOptions,
+  TokenNormalizedSet,
+} from '../types.js';
+import { calculatePermutations } from './load.js';
+
+function resolveTokens({
+  input,
+  resolutionOrder,
+  logger,
+  options,
+}: ResolveTokensOptions): TokenNormalizedSet {
+  const tokensRaw: TokenNormalizedSet = {};
+
+  for (const item of resolutionOrder) {
+    switch (item.type) {
+      case 'set': {
+        if (Array.isArray(options?.sets) && !options.sets.includes(item.name)) {
+          continue;
+        }
+        for (const source of item.sources) {
+          destructiveMerge(tokensRaw, source);
+        }
+        break;
+      }
+      case 'modifier': {
+        if (Array.isArray(options?.modifiers) && !options.modifiers.includes(item.name)) {
+          continue;
+        }
+        const context = input[item.name];
+
+        if (!context) {
+          continue;
+        }
+
+        const resolverSources = item.contexts[context];
+        if (!resolverSources) {
+          logger.error({
+            group: 'resolver',
+            message: `Modifier ${item.name} has no context ${JSON.stringify(context)}.`,
+          });
+        }
+        for (const source of resolverSources ?? []) {
+          destructiveMerge(tokensRaw, source);
+        }
+        break;
+      }
+    }
+  }
+
+  return tokensRaw;
+}
+
+function resolveAllPermutations(
+  resolver: Resolver,
+  options?: { modifiers?: string[]; resolveAliases?: boolean },
+) {
+  const { modifiers, resolveAliases } = options || {};
+  const possiblePermutations = resolver.listPermutations?.() || [];
+
+  const resolvedTokens = possiblePermutations.map((input) => ({
+    input,
+    tokens: resolver.apply(input, {
+      modifiers,
+      resolveAliases,
+    }),
+  }));
+
+  return resolvedTokens;
+}
+
+/** Create an interface to resolve permutations */
+export function createResolver(
+  resolverSource: ResolverSourceNormalized,
+  { config, logger, sources, orthogonal }: CreateResolverOptions,
+): Resolver {
+  const inputDefault: ResolverInput = {};
+  const validContexts: Record<string, string[]> = {};
+  const allPermutations: ResolverInput[] = [];
+  const resolverCache: Record<string, TokenNormalizedSet> = {};
+
+  // Important: by iterating over resolutionOrder, we
+  // filter out unused modifiers/irrelevant contexts.
+  for (const source of resolverSource.resolutionOrder) {
+    if (source.type === 'modifier') {
+      if (typeof source.default === 'string') {
+        inputDefault[source.name] = source.default;
+      }
+      validContexts[source.name] = Object.keys(source.contexts);
+    }
+  }
+
+  const permutationCount = Object.values(validContexts).reduce(
+    (acc, context) => acc * context.length,
+    1,
+  );
+
+  function getProcessedTokens(tokensRaw: TokenNormalizedSet, options?: ResolverApplicationOptions) {
+    if (!resolverSource._source.filename) {
+      return;
+    }
+
+    const src = JSON.stringify(tokensRaw, null, 2);
+    const rootSource = {
+      filename: resolverSource._source.filename,
+      document: toMomoa(src),
+      src,
+    };
+
+    const tokens = processTokens(rootSource, {
+      config,
+      logger,
+      sourceByFilename: { [resolverSource._source.filename.href]: rootSource },
+      isResolver: true,
+      resolveAliases: options?.resolveAliases ?? true,
+      sources,
+    });
+
+    return tokens;
+  }
+
+  return {
+    orthogonal,
+    source: resolverSource,
+    inputDefault,
+    listPermutations:
+      permutationCount <= config.permutationLimit
+        ? () => {
+            // only do work on first call, then cache subsequent work. this could be thousands of possible values!
+            if (allPermutations.length === 0) {
+              allPermutations.push(...calculatePermutations(Object.entries(validContexts)));
+            }
+            return allPermutations;
+          }
+        : undefined,
+    apply(inputRaw, options) {
+      const input = { ...inputDefault, ...inputRaw };
+      const permutationID = getPermutationID(input, options);
+
+      if (resolverCache[permutationID]) {
+        return resolverCache[permutationID];
+      }
+
+      if (!resolverSource._source.filename) {
+        logger.error({
+          group: 'resolver',
+          message: 'Resolver source has no filename property.',
+        });
+
+        return {};
+      }
+
+      const tokensRaw = resolveTokens({
+        input,
+        resolutionOrder: resolverSource.resolutionOrder,
+        logger,
+        options,
+      });
+
+      const tokens = getProcessedTokens(tokensRaw, options) || {};
+
+      resolverCache[permutationID] = tokens;
+
+      return tokens;
+    },
+    isValidInput(input, throwError = false) {
+      if (!input || typeof input !== 'object') {
+        logger.error({ group: 'resolver', message: `Invalid input: ${JSON.stringify(input)}.` });
+      }
+      for (const modifier of Object.keys(input)) {
+        if (!(modifier in validContexts)) {
+          if (throwError) {
+            logger.error({
+              group: 'resolver',
+              message: `No such modifier ${JSON.stringify(modifier)}`,
+            });
+          }
+          return false; // 1. invalid if unknown modifier name
+        }
+      }
+      for (const [name, contexts] of Object.entries(validContexts)) {
+        // Note: empty strings are valid! Don’t check for truthiness.
+        if (typeof input[name] === 'string') {
+          if (name === 'tzMode') {
+            continue; // reserved modifier
+          }
+          if (!contexts.includes(input[name])) {
+            if (throwError) {
+              logger.error({
+                group: 'resolver',
+                message: `Modifier "${name}" has no context ${JSON.stringify(input[name])}.`,
+              });
+            }
+            return false; // 2. invalid if unknown context
+          }
+        } else if (!(name in inputDefault)) {
+          if (throwError) {
+            logger.error({
+              group: 'resolver',
+              message: `Modifier "${name}" missing value (no default set).`,
+            });
+          }
+          return false; // 3. invalid if omitted, and no default
+        }
+      }
+      return true;
+    },
+    getPermutationID(input) {
+      this.isValidInput(input, true);
+      return getPermutationID({ ...inputDefault, ...input });
+    },
+    intersection(options) {
+      const permutationID = `intersection_${getPermutationID(inputDefault, options)}`;
+
+      if (resolverCache[permutationID]) {
+        return resolverCache[permutationID];
+      }
+
+      const [first, ...rest] = resolveAllPermutations(this, options);
+
+      if (!first?.tokens) {
+        return {};
+      }
+
+      const commonTokens = Object.entries(first.tokens).reduce((acc, [id, token]) => {
+        if (typeof options?.filter === 'function' && !options.filter?.(token)) {
+          return acc;
+        }
+
+        const isCommon = rest.every(({ tokens }) => {
+          const otherToken = tokens[id];
+          return otherToken && JSON.stringify(otherToken.$value) === JSON.stringify(token.$value);
+        });
+
+        if (isCommon) {
+          acc[id] = token;
+        }
+        return acc;
+      }, {} as TokenNormalizedSet);
+
+      resolverCache[permutationID] = commonTokens;
+
+      return commonTokens;
+    },
+    symmetricDifference(options) {
+      const permutationID = `symmetricDifference_${getPermutationID(inputDefault, options)}`;
+
+      if (resolverCache[permutationID]) {
+        return resolverCache[permutationID];
+      }
+
+      const [first, ...rest] = resolveAllPermutations(this, options);
+
+      if (!first?.tokens) {
+        return {};
+      }
+
+      const uniqueTokens = Object.entries(first.tokens).reduce((acc, [id, token]) => {
+        if (typeof options?.filter === 'function' && !options.filter?.(token)) {
+          return acc;
+        }
+
+        const isUnique = rest.some(({ tokens }) => {
+          const otherToken = tokens[id];
+          return otherToken && JSON.stringify(otherToken.$value) !== JSON.stringify(token.$value);
+        });
+
+        if (isUnique) {
+          acc[id] = token;
+        }
+        return acc;
+      }, {} as TokenNormalizedSet);
+
+      resolverCache[permutationID] = uniqueTokens;
+
+      return uniqueTokens;
+    },
+  };
+}

--- a/packages/parser/src/resolver/create-synthetic-resolver.ts
+++ b/packages/parser/src/resolver/create-synthetic-resolver.ts
@@ -3,7 +3,7 @@ import type { InputSourceWithDocument } from '@terrazzo/json-schema-tools';
 
 import type Logger from '../logger.js';
 import type { ConfigInit, Group, Resolver, TokenNormalized, TokenNormalizedSet } from '../types.js';
-import { createResolver } from './load.js';
+import { createResolver } from './create-resolver.js';
 import { normalizeResolver } from './normalize.js';
 
 export interface CreateSyntheticResolverOptions {

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -5,22 +5,18 @@ import {
   maybeRawJSON,
 } from '@terrazzo/json-schema-tools';
 import type { TokenNormalizedSet } from '@terrazzo/token-tools';
-import type yamlToMomoa from 'yaml-to-momoa';
 
 import { toMomoa } from '../lib/momoa.js';
-import { destructiveMerge, getPermutationID } from '../lib/resolver-utils.js';
 import type Logger from '../logger.js';
-import { processTokens } from '../parse/process.js';
-import type { ConfigInit, Resolver, ResolverInput, ResolverSourceNormalized } from '../types.js';
+import type {
+  LoadResolverOptions,
+  Resolver,
+  ResolverInput,
+  ResolverSourceNormalized,
+} from '../types.js';
+import { createResolver } from './create-resolver.js';
 import { normalizeResolver } from './normalize.js';
 import { isLikelyResolver, validateResolver } from './validate.js';
-
-export interface LoadResolverOptions {
-  config: ConfigInit;
-  logger: Logger;
-  req: (url: URL, origin: URL) => Promise<string>;
-  yamlToMomoa?: typeof yamlToMomoa;
-}
 
 /** Quick-parse input sources and find a resolver */
 export async function loadResolver(
@@ -116,174 +112,6 @@ export async function loadResolver(
   };
 }
 
-export interface CreateResolverOptions {
-  config: ConfigInit;
-  logger: Logger;
-  sources: InputSourceWithDocument[];
-  orthogonal: boolean;
-}
-
-/** Create an interface to resolve permutations */
-export function createResolver(
-  resolverSource: ResolverSourceNormalized,
-  { config, logger, sources, orthogonal }: CreateResolverOptions,
-): Resolver {
-  const inputDefaults: ResolverInput = {};
-  const validContexts: Record<string, string[]> = {};
-  const allPermutations: ResolverInput[] = [];
-
-  const resolverCache: Record<string, any> = {};
-
-  // Important: by iterating over resolutionOrder, we
-  // filter out unused modifiers/irrelevant contexts.
-  for (const m of resolverSource.resolutionOrder) {
-    if (m.type === 'modifier') {
-      if (typeof m.default === 'string') {
-        inputDefaults[m.name] = m.default!;
-      }
-      validContexts[m.name] = Object.keys(m.contexts);
-    }
-  }
-
-  const permutationCount = Object.values(validContexts).reduce(
-    (acc, context) => acc * context.length,
-    1,
-  );
-
-  return {
-    apply(inputRaw, options) {
-      const tokensRaw: TokenNormalizedSet = {};
-      const input = { ...inputDefaults, ...inputRaw };
-      const permutationID = getPermutationID(input, options);
-
-      if (resolverCache[permutationID]) {
-        return resolverCache[permutationID];
-      }
-
-      for (const item of resolverSource.resolutionOrder) {
-        switch (item.type) {
-          case 'set': {
-            if (Array.isArray(options?.sets) && !options.sets.includes(item.name)) {
-              continue;
-            }
-            for (const s of item.sources) {
-              destructiveMerge(tokensRaw, s);
-            }
-            break;
-          }
-          case 'modifier': {
-            if (Array.isArray(options?.modifiers) && !options.modifiers.includes(item.name)) {
-              continue;
-            }
-            const context = input[item.name]!;
-            const resolverSources = item.contexts[context];
-            if (!resolverSources) {
-              logger.error({
-                group: 'resolver',
-                message: `Modifier ${item.name} has no context ${JSON.stringify(context)}.`,
-              });
-            }
-            for (const s of resolverSources ?? []) {
-              destructiveMerge(tokensRaw, s);
-            }
-            break;
-          }
-        }
-      }
-
-      const src = JSON.stringify(tokensRaw, undefined, 2);
-      const rootSource = {
-        filename: resolverSource._source.filename!,
-        document: toMomoa(src),
-        src,
-      };
-      const tokens = processTokens(rootSource, {
-        config,
-        logger,
-        sourceByFilename: { [resolverSource._source.filename!.href]: rootSource },
-        isResolver: true,
-        resolveAliases: options?.resolveAliases ?? true,
-        sources,
-      });
-      resolverCache[permutationID] = tokens;
-      return tokens;
-    },
-    orthogonal,
-    source: resolverSource,
-    listPermutations:
-      permutationCount <= config.permutationLimit
-        ? () => {
-            // only do work on first call, then cache subsequent work. this could be thousands of possible values!
-            if (allPermutations.length === 0) {
-              allPermutations.push(...calculatePermutations(Object.entries(validContexts)));
-            }
-            return allPermutations;
-          }
-        : undefined,
-    isValidInput(input, throwError = false) {
-      if (!input || typeof input !== 'object') {
-        logger.error({ group: 'resolver', message: `Invalid input: ${JSON.stringify(input)}.` });
-      }
-      for (const k of Object.keys(input)) {
-        if (!(k in validContexts)) {
-          if (throwError) {
-            logger.error({ group: 'resolver', message: `No such modifier ${JSON.stringify(k)}` });
-          }
-          return false; // 1. invalid if unknown modifier name
-        }
-      }
-      for (const [name, contexts] of Object.entries(validContexts)) {
-        // Note: empty strings are valid! Don’t check for truthiness.
-        if (name in input) {
-          if (name === 'tzMode') {
-            continue; // reserved modifier
-          }
-          if (!contexts.includes(input[name]!)) {
-            if (throwError) {
-              logger.error({
-                group: 'resolver',
-                message: `Modifier "${name}" has no context ${JSON.stringify(input[name])}.`,
-              });
-            }
-            return false; // 2. invalid if unknown context
-          }
-        } else if (!(name in inputDefaults)) {
-          if (throwError) {
-            logger.error({
-              group: 'resolver',
-              message: `Modifier "${name}" missing value (no default set).`,
-            });
-          }
-          return false; // 3. invalid if omitted, and no default
-        }
-      }
-      return true;
-    },
-    getPermutationID(input) {
-      this.isValidInput(input, true);
-      return getPermutationID({ ...inputDefaults, ...input });
-    },
-  };
-}
-
-/** Calculate all permutations */
-export function calculatePermutations(options: [string, string[]][]) {
-  const permutationCount = [1];
-  for (const [_name, contexts] of options) {
-    permutationCount.push(contexts.length * (permutationCount.at(-1) || 1));
-  }
-  const permutations: Record<string, string>[] = [];
-  for (let i = 0; i < permutationCount.at(-1)!; i++) {
-    const input: ResolverInput = {};
-    for (let j = 0; j < options.length; j++) {
-      const [name, contexts] = options[j]!;
-      input[name] = contexts[Math.floor(i / permutationCount[j]!) % contexts.length]!;
-    }
-    permutations.push(input);
-  }
-  return permutations.length > 0 ? permutations : [{}];
-}
-
 /** Determine Resolver orthogonality using as little work as possible */
 function isResolverOrthogonal(resolver: ResolverSourceNormalized, logger: Logger): boolean {
   // Keep a record of which tokens are in which modifier.
@@ -350,4 +178,22 @@ function isResolverOrthogonal(resolver: ResolverSourceNormalized, logger: Logger
   }
 
   return true;
+}
+
+/** Calculate all permutations */
+export function calculatePermutations(options: [string, string[]][]) {
+  const permutationCount = [1];
+  for (const [_name, contexts] of options) {
+    permutationCount.push(contexts.length * (permutationCount.at(-1) || 1));
+  }
+  const permutations: Record<string, string>[] = [];
+  for (let i = 0; i < permutationCount.at(-1)!; i++) {
+    const input: ResolverInput = {};
+    for (let j = 0; j < options.length; j++) {
+      const [name, contexts] = options[j]!;
+      input[name] = contexts[Math.floor(i / permutationCount[j]!) % contexts.length]!;
+    }
+    permutations.push(input);
+  }
+  return permutations.length > 0 ? permutations : [{}];
 }

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -361,7 +361,7 @@ export interface ResolverApplicationOptions {
    * Limit input application only to the listed sets.
    *
    * In combination with `modifiers`, this will limit output to only
-   * tokens declared within the options given. If tokens are referenced by alises
+   * tokens declared within the options given. If tokens are referenced by aliases
    * outside these options, the application will fail unless `resolveAliases` is
    * set to false.
    */
@@ -370,17 +370,54 @@ export interface ResolverApplicationOptions {
    * Limit input application only to the listed modifiers.
    *
    * In combination with `sets`, this will limit output to only
-   * tokens declared within the options given. If tokens are referenced by alises
+   * tokens declared within the options given. If tokens are referenced by aliases
    * outside these options, the application will fail unless `resolveAliases` is
    * set to false.
    */
   modifiers?: string[];
 }
 
+export interface ResolverCommutativeSetOperationOptions {
+  /**
+   * Resolve DTCG aliases when applying the input.
+   *
+   * @default true
+   */
+  resolveAliases?: boolean;
+  /**
+   * Limit input application only to the listed modifiers.
+   *
+   * this will limit output to only tokens declared within the options given.
+   * If the tokens are referenced by aliases outside these options,
+   * the application will fail unless `resolveAliases` is set to false.
+   */
+  modifiers?: string[];
+
+  /**
+   * Filter tokens based on specific criteria.
+   */
+  filter?: (token: TokenNormalized) => boolean;
+}
+
 export interface Resolver<
   Inputs extends Record<string, string[]> = Record<string, string[]>,
   Input = Record<keyof Inputs, Inputs[keyof Inputs][number]>,
 > {
+  /**
+   * Do all modifiers in this resolver operate on unique tokens?
+   *
+   * This is all-or-nothing, if even a single token is referenced in 2
+   * modifiers, the entire resolver is non-orthogonal.
+   */
+  orthogonal: boolean;
+  /**
+   * Default input for this resolver based on the default context of each modifiers
+   */
+  inputDefault: ResolverInput;
+  /**
+   * The original resolver document, simplified
+   */
+  source: ResolverSourceNormalized;
   /**
    * Supply values to modifiers to produce a final tokens set. This caches the
    * results, so calling a 2nd time with the same inputs will return the same
@@ -398,17 +435,22 @@ export interface Resolver<
   listPermutations?: () => Input[];
   /* Generate a stable ID from any input */
   getPermutationID: (input: Input) => string;
-  /** The original resolver document, simplified */
-  source: ResolverSourceNormalized;
   /** Helper function for permutations—see if a particular input is valid. Automatically applies default values. */
   isValidInput: (input: Input, throwError?: boolean) => boolean;
   /**
-   * Do all modifiers in this resolver operate on unique tokens?
+   * Produce a token set that only contains tokens with the same value across the different modifiers passed as options.
+   * If no modifiers option is passed, it will return the tokens with the same value across all modifier permutations.
    *
-   * This is all-or-nothing, if even a single token is referenced in 2
-   * modifiers, the entire resolver is non-orthogonal.
+   * This is useful for generating a "baseline" set of tokens that are guaranteed to be present across different permutations.
    */
-  orthogonal: boolean;
+  intersection(options?: ResolverCommutativeSetOperationOptions): TokenNormalizedSet;
+  /**
+   * Produce a token set that only contains tokens with unique values across the different modifiers passed as options.
+   * If no modifiers option is passed, it will return the tokens with unique values across all modifier permutations.
+   *
+   * This is useful for generating sets of tokens that have unique values across their permutations.
+   */
+  symmetricDifference(options?: ResolverCommutativeSetOperationOptions): TokenNormalizedSet;
 }
 
 export interface ResolverSource {
@@ -557,3 +599,24 @@ export interface RefMapEntry {
 }
 
 export type RefMap = Record<string, RefMapEntry>;
+
+export interface CreateResolverOptions {
+  config: ConfigInit;
+  logger: Logger;
+  sources: InputSourceWithDocument[];
+  orthogonal: boolean;
+}
+
+export interface LoadResolverOptions {
+  config: ConfigInit;
+  logger: Logger;
+  req: (url: URL, origin: URL) => Promise<string>;
+  yamlToMomoa?: typeof ytm;
+}
+
+export interface ResolveTokensOptions {
+  input: Partial<ResolverInput>;
+  resolutionOrder: ResolverSourceNormalized['resolutionOrder'];
+  logger: Logger;
+  options?: ResolverApplicationOptions;
+}

--- a/packages/parser/test/fixtures/resolver-set-operation/invariants.json
+++ b/packages/parser/test/fixtures/resolver-set-operation/invariants.json
@@ -1,0 +1,28 @@
+{
+"purple": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.4,
+        0.2,
+        0.6
+      ],
+      "alpha": 1,
+      "hex": "#663399"
+    },
+    "$type": "color"
+  },
+  "papaya": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        1,
+        0.9,
+        0.8
+      ],
+      "alpha": 1,
+      "hex": "#ffefd5"
+    },
+    "$type": "color"
+  }
+}

--- a/packages/parser/test/fixtures/resolver-set-operation/modes.json
+++ b/packages/parser/test/fixtures/resolver-set-operation/modes.json
@@ -1,0 +1,54 @@
+{
+  "mode-light": {
+    "orange": {
+      "$value": "{light-orange-400}"
+    },
+    "blue": {
+      "$value": "{light-blue-400}"
+    },
+    "light-blue": {
+      "$value": "{light-blue-200}"
+    },
+    "dark-blue": {
+      "$value": "{dark-blue-800}"
+    },
+    "light-grey": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8,
+          0.8,
+          0.8
+        ],
+        "alpha": 1,
+        "hex": "#cccccc"
+      }
+    }
+  },
+  "mode-dark": {
+    "orange": {
+      "$value": "{dark-orange-400}"
+    },
+    "blue": {
+      "$value": "{dark-blue-400}"
+    },
+    "light-blue": {
+      "$value": "{light-blue-200}"
+    },
+    "dark-blue": {
+      "$value": "{dark-blue-800}"
+    },
+    "light-grey": {
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9,
+          0.9,
+          0.9
+        ],
+        "alpha": 1,
+        "hex": "#e6e6e6"
+      }
+    }
+  }
+}

--- a/packages/parser/test/fixtures/resolver-set-operation/primitives.json
+++ b/packages/parser/test/fixtures/resolver-set-operation/primitives.json
@@ -1,0 +1,210 @@
+{
+  "light-blue-200": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.8,
+        0.9,
+        1
+      ],
+      "alpha": 1,
+      "hex": "#cce5ff"
+    },
+    "$type": "color"
+  },
+  "light-blue-400": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.6,
+        0.8,
+        1
+      ],
+      "alpha": 1,
+      "hex": "#99ccff"
+    },
+    "$type": "color"
+  },
+  "light-blue-600": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.4,
+        0.7,
+        1
+      ],
+      "alpha": 1,
+      "hex": "#66b2ff"
+    },
+    "$type": "color"
+  },
+  "light-blue-800": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.2,
+        0.6,
+        1
+      ],
+      "alpha": 1,
+      "hex": "#3399ff"
+    },
+    "$type": "color"
+  },
+  "dark-blue-200": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0,
+        0.13,
+        0.8
+      ],
+      "alpha": 1,
+      "hex": "#0022cc"
+    },
+    "$type": "color"
+  },
+  "dark-blue-400": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0,
+        0.1,
+        0.6
+      ],
+      "alpha": 1,
+      "hex": "#001a99"
+    },
+    "$type": "color"
+  },
+  "dark-blue-600": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0,
+        0.06,
+        0.4
+      ],
+      "alpha": 1,
+      "hex": "#001166"
+    },
+    "$type": "color"
+  },
+  "dark-blue-800": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0,
+        0.03,
+        0.2
+      ],
+      "alpha": 1,
+      "hex": "#000933"
+    },
+    "$type": "color"
+  },
+  "light-orange-200": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        1,
+        0.93,
+        0.8
+      ],
+      "alpha": 1,
+      "hex": "#ffeecc"
+    },
+    "$type": "color"
+  },
+  "light-orange-400": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        1,
+        0.86,
+        0.6
+      ],
+      "alpha": 1,
+      "hex": "#ffdd99"
+    },
+    "$type": "color"
+  },
+  "light-orange-600": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        1,
+        0.8,
+        0.4
+      ],
+      "alpha": 1,
+      "hex": "#ffcc66"
+    },
+    "$type": "color"
+  },
+  "light-orange-800": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        1,
+        0.73,
+        0.2
+      ],
+      "alpha": 1,
+      "hex": "#ffbb33"
+    },
+    "$type": "color"
+  },
+  "dark-orange-200": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.8,
+        0.32,
+        0
+      ],
+      "alpha": 1,
+      "hex": "#cc5200"
+    },
+    "$type": "color"
+  },
+  "dark-orange-400": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.6,
+        0.25,
+        0
+      ],
+      "alpha": 1,
+      "hex": "#994000"
+    },
+    "$type": "color"
+  },
+  "dark-orange-600": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.4,
+        0.17,
+        0
+      ],
+      "alpha": 1,
+      "hex": "#662b00"
+    },
+    "$type": "color"
+  },
+  "dark-orange-800": {
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [
+        0.2,
+        0.08,
+        0
+      ],
+      "alpha": 1,
+      "hex": "#331500"
+    },
+    "$type": "color"
+  }
+}

--- a/packages/parser/test/fixtures/resolver-set-operation/resolver.json
+++ b/packages/parser/test/fixtures/resolver-set-operation/resolver.json
@@ -1,0 +1,34 @@
+{
+  "version": "2025.10",
+  "name": "orange-blue",
+  "sets": {
+    "primitives": {
+      "sources": [{ "$ref": "primitives.json" }]
+    },
+    "invariants": {
+      "sources": [{ "$ref": "invariants.json" }]
+    }
+  },
+  "modifiers": {
+    "theme": {
+      "default": "orange",
+      "contexts": {
+        "orange": [{ "$ref": "themes.json#theme-orange" }],
+        "blue": [{ "$ref": "themes.json#theme-blue" }]
+      }
+    },
+    "mode": {
+      "default": "light",
+      "contexts": {
+        "light": [{ "$ref": "modes.json#mode-light" }],
+        "dark": [{ "$ref": "modes.json#mode-dark" }]
+      }
+    }
+  },
+  "resolutionOrder": [
+    { "$ref": "#/modifiers/theme" },
+    { "$ref": "#/modifiers/mode" },
+    { "$ref": "#/sets/primitives" },
+    { "$ref": "#/sets/invariants" }
+  ]
+}

--- a/packages/parser/test/fixtures/resolver-set-operation/themes.json
+++ b/packages/parser/test/fixtures/resolver-set-operation/themes.json
@@ -1,0 +1,18 @@
+{
+  "theme-orange": {
+    "main-color": {
+      "$value": "{light-orange-400}"
+    },
+    "secondary-color": {
+      "$value": "{dark-blue-400}"
+    }
+  },
+  "theme-blue": {
+    "main-color": {
+      "$value": "{light-blue-400}"
+    },
+    "secondary-color": {
+      "$value": "{dark-blue-400}"
+    }
+  }
+}

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -579,6 +579,7 @@ describe('partial application', () => {
   it('returns only tokens from a set', async () => {
     const resolver = await loadResolver();
     const tokens = resolver.apply({}, { modifiers: [], sets: ['primitives'] });
+
     expect(new Set(Object.keys(tokens))).toEqual(
       new Set(['dark-blue', 'dark-orange', 'light-blue', 'light-orange']),
     );
@@ -598,6 +599,153 @@ describe('partial application', () => {
       { modifiers: ['theme'], sets: [], resolveAliases: false },
     );
     expect(new Set(Object.keys(themeTokens))).toEqual(new Set(['color']));
+  });
+});
+
+describe('set operations', () => {
+  // oxlint-disable-next-line consistent-function-scoping
+  async function loadResolver() {
+    const cwd = new URL('./fixtures/resolver-set-operation/', import.meta.url);
+    const filename = new URL('./resolver.json', cwd);
+    const config = defineConfig({}, { cwd });
+    const result = await parse(
+      [
+        {
+          filename,
+          src: await fs.readFile(filename, 'utf8'),
+        },
+      ],
+      { config },
+    );
+    return result.resolver;
+  }
+
+  const primitiveSetTokens = [
+    'dark-blue-200',
+    'dark-blue-400',
+    'dark-blue-600',
+    'dark-blue-800',
+    'dark-orange-200',
+    'dark-orange-400',
+    'dark-orange-600',
+    'dark-orange-800',
+    'light-blue-200',
+    'light-blue-400',
+    'light-blue-600',
+    'light-blue-800',
+    'light-orange-200',
+    'light-orange-400',
+    'light-orange-600',
+    'light-orange-800',
+  ];
+
+  //////////////////////////
+  ///// intersection() /////
+  //////////////////////////
+  it('returns all tokens with the same value across all modifiers permutations', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.intersection();
+
+    expect(new Set(Object.keys(tokens))).toEqual(
+      new Set([
+        'dark-blue',
+        'light-blue',
+        'secondary-color',
+        'papaya',
+        'purple',
+        ...primitiveSetTokens,
+      ]),
+    );
+  });
+
+  it('returns only non alias tokens with the same value across all modifiers permutations', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.intersection({ filter: (token) => !token.aliasOf?.length });
+
+    expect(new Set(Object.keys(tokens))).toEqual(
+      new Set(['papaya', 'purple', ...primitiveSetTokens]),
+    );
+  });
+
+  it('returns only alias tokens with the same value across all modifiers permutations', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.intersection({ filter: (token) => !!token.aliasOf?.length });
+
+    expect(new Set(Object.keys(tokens))).toEqual(
+      new Set(['dark-blue', 'light-blue', 'secondary-color']),
+    );
+  });
+
+  it('returns only alias tokens with the same value across all permutations in the "mode" modifier subset', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.intersection({
+      filter: (token) => !!token.aliasOf?.length,
+      modifiers: ['mode'],
+    });
+
+    expect(new Set(Object.keys(tokens))).toEqual(new Set(['dark-blue', 'light-blue']));
+  });
+
+  it('returns only alias tokens with the same value across all permutations in the "mode" and "theme" modifiers subset', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.intersection({
+      filter: (token) => !!token.aliasOf?.length,
+      modifiers: ['mode', 'theme'],
+    });
+
+    expect(new Set(Object.keys(tokens))).toEqual(
+      new Set(['dark-blue', 'light-blue', 'secondary-color']),
+    );
+  });
+
+  /////////////////////////////////
+  ///// symmetricDifference() /////
+  /////////////////////////////////
+  it('returns all tokens with unique values across all modifiers permutations', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.symmetricDifference();
+
+    expect(new Set(Object.keys(tokens))).toEqual(
+      new Set(['main-color', 'blue', 'orange', 'light-grey']),
+    );
+  });
+
+  it('returns only non alias tokens with unique values across all modifiers permutations', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.symmetricDifference({
+      filter: (token) => !token.aliasOf?.length,
+    });
+
+    expect(new Set(Object.keys(tokens))).toEqual(new Set(['light-grey']));
+  });
+
+  it('returns only alias tokens with unique values across all modifiers permutations', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.symmetricDifference({
+      filter: (token) => !!token.aliasOf?.length,
+    });
+
+    expect(new Set(Object.keys(tokens))).toEqual(new Set(['main-color', 'blue', 'orange']));
+  });
+
+  it('returns only alias tokens with unique values across all permutations in the "theme" modifier subset', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.symmetricDifference({
+      filter: (token) => !!token.aliasOf?.length,
+      modifiers: ['theme'],
+    });
+
+    expect(new Set(Object.keys(tokens))).toEqual(new Set(['main-color']));
+  });
+
+  it('returns only alias tokens with unique values across all permutations in the "theme" and "mode" modifiers subset', async () => {
+    const resolver = await loadResolver();
+    const tokens = resolver.symmetricDifference({
+      filter: (token) => !!token.aliasOf?.length,
+      modifiers: ['theme', 'mode'],
+    });
+
+    expect(new Set(Object.keys(tokens))).toEqual(new Set(['main-color', 'blue', 'orange']));
   });
 });
 

--- a/www/src/pages/docs/reference/js-api.md
+++ b/www/src/pages/docs/reference/js-api.md
@@ -44,7 +44,7 @@ for (const { filename, contents } of buildResult) {
 It’s worth noting the JS API is a little more manual work than the [CLI](/docs/):
 
 - `parse()` and `build()` are distinct steps that each do some of the work.
-- `defineConfig()` needs a <abbr title="Current Working Directory">cwd</abbr> so it can resolve files (this can even be a remote URL, so long as it’s a URL())
+- `defineConfig()` needs a <abbr title="Current Working Directory">cwd</abbr> so it can resolve files (this can even be a remote URL, so long as it’s a `URL()` object)
 - The AST generated from `parse()` must get passed into `build()` so the error messages can point to the right lines in the source file.
 - The `build()` step only returns a final array of `outputFiles`in memory but doesn’t write them to disk. It’s up to you to write them to disk, upload them somewhere, etc.
 
@@ -278,7 +278,7 @@ import { parse } from "@terrazzo/parser";
 
 const { resolver } = await parse(sources, { config });
 
-resolver.apply({ theme: "light" }, { modifiers: ["theme"], resolveAliases: false });
+const tokens = resolver.apply({ theme: "light" }, { modifiers: ["theme"], resolveAliases: false });
 ```
 
 It may be useful to apply an input to only a specific subset of tokens within the resolver.
@@ -294,17 +294,65 @@ partial application.
 Note that `$extends` directives that reference tokens outside of the subset will fail to resolve
 regardless of the `resolveAliases` setting.
 
+### Set operations
+
+Set operations allows you to filter tokens based on the permutations of the resolver.
+
+They can be useful for filtering tokens whose values don't change across modifiers, or on the contrary, tokens whose values change across modifiers.
+
+:::tip
+`intersection` and `symmetricalDifference` perform commutative set operations, meaning that the order of the modifiers doesn't change the result.
+:::
+
+Both accept the same `ResolverCommutativeSetOperationOptions` options, which are:
+
+| Name               | Type                                               | Default     | Description                                                                       |
+| :----------------- | :------------------------------------------------- | :---------- | :-------------------------------------------------------------------------------- |
+| **modifiers**      | `undefined \| string[]`                            | `[]`        | Like the `apply` method, restrict the operation to the included modifiers subset. |
+| **resolveAliases** | `undefined \| boolean`                             | `true`      | Like the `apply` method, resolve DTCG aliases when applying the input.            |
+| **filter**         | `undefined \| (token: TokenNormalized) => boolean` | `undefined` | Filter tokens based on specific criteria.                                         |
+
+#### intersection
+
+```ts
+import { parse } from "@terrazzo/parser";
+
+const { resolver } = await parse(sources, { config });
+
+const tokens = resolver.intersection({
+  modifiers: ["theme"],
+  filter: (token) => !!token.aliasOf?.length,
+});
+```
+
+In the above example `tokens` will contain all the tokens that have unchanged values across all permutations of the `theme` modifier, and that are aliases.
+
+#### symmetricDifference
+
+```ts
+import { parse } from "@terrazzo/parser";
+
+const { resolver } = await parse(sources, { config });
+
+const tokens = resolver.symmetricDifference({ modifiers: ["theme", "mode"] });
+```
+
+In this example, `symmetricDifference` does the opposite of `intersection`, in this case `tokens` will contain all the tokens that have changing values across all the permutations of the `theme` and `mode` modifiers.
+This time, we also do not use the `filter` option.
+
 ### API
 
 #### createResolver
 
-`createResolver(resolverSource: ResolverSourceNormalized, resolverOptions: CreateResolverOptions)` returns a resolver with the following methods:
+`createResolver(resolverSource: ResolverSourceNormalized, resolverOptions: CreateResolverOptions)` returns a resolver with the following properties:
 
-| Name                 | Type                                                                                          | Description                                                                                                                                           |
-| :------------------- | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **apply**            | `(input: Record<string, string>, options?: ResolverApplicationOptions) => TokenNormalizedSet` | Apply [inputs](https://www.designtokens.org/tr/2025.10/resolver/#inputs) to the resolver.                                                             |
-| **listPermutations** | `undefined \| () => Record<string, string>[]`                                                 | Get all valid inputs for all [modifiers](https://www.designtokens.org/tr/2025.10/resolver/#modifiers).                                                |
-| **isValidInput**     | `(input: Record<string, string>, throwError?: boolean) => boolean`                            | Returns a boolean value if a given input meets the resolver requirements. Optionally pass `true` for the 2nd param to throw errors with helpful info. |
-| **getPermutationID** | `(input: Record<string, string>) => string`                                                   | Returns a stable, deterministic ID from an input. This can also be parsed by JSON back into a normalized input.                                       |
-| **orthogonal**       | `boolean`                                                                                     | Returns `true` if all modifiers operate on unique tokens. This is all-or-nothing—a resolver is only orthogonal if all modifiers are.                  |
-| **source**           | `ResolverSourceNormalized`                                                                    | The resolver source, a representation of the resolver.json file where all tokens are loaded and flattened in-memory for performance reason.           |
+| Name                    | Type                                                                                          | Description                                                                                                                                           |
+| :---------------------- | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **apply**               | `(input: Record<string, string>, options?: ResolverApplicationOptions) => TokenNormalizedSet` | Apply [inputs](https://www.designtokens.org/tr/2025.10/resolver/#inputs) to the resolver.                                                             |
+| **listPermutations**    | `undefined \| () => Record<string, string>[]`                                                 | Get all valid inputs for all [modifiers](https://www.designtokens.org/tr/2025.10/resolver/#modifiers).                                                |
+| **isValidInput**        | `(input: Record<string, string>, throwError?: boolean) => boolean`                            | Returns a boolean value if a given input meets the resolver requirements. Optionally pass `true` for the 2nd param to throw errors with helpful info. |
+| **getPermutationID**    | `(input: Record<string, string>) => string`                                                   | Returns a stable, deterministic ID from an input. This can also be parsed by JSON back into a normalized input.                                       |
+| **intersection**        | `(options?: ResolverCommutativeSetOperationOptions) => TokenNormalizedSet`                    | Use `apply()` then does an intersection operation and return a token set where all the tokens have unchanged values across permutations.              |
+| **symmetricDifference** | `(options?: ResolverCommutativeSetOperationOptions) => TokenNormalizedSet`                    | Use `apply()` then does an symmetric difference operation and return a token set where all the tokens have changed values across permutations.        |
+| **orthogonal**          | `boolean`                                                                                     | Returns `true` if all modifiers operate on unique tokens. This is all-or-nothing—a resolver is only orthogonal if all modifiers are.                  |
+| **source**              | `ResolverSourceNormalized`                                                                    | The resolver source, a representation of the resolver.json file where all tokens are loaded and flattened in-memory for performance reason.           |


### PR DESCRIPTION
This PR adds utility functions to the resolver to manipulate and filter resolved tokens.

## Motivations
My team and I have trouble converting our codebase to use the resolver, one of the reasons is that we have to do some amount of filtering of the resolved tokens ourselves, which we could avoid when using legacy modes.

For example, for optimization reasons, we want to be able to filter out all the tokens common to every modifiers (meaning their value don't change), in order to create a `common.css` file, and then have tokens which values are exclusive to a modifier context in their own `{modifier}-{context}.css` files. This way, tokens with the same values across all modifiers are stored in one file, and we avoid having duplicated tokens in other files.

## Changes

This PR adds 2 methods in `resolver.extra`:

`intersection(options)`: returns all tokens that don't change value across modifiers

`symmetricDifference(options)`: returns all tokens on which the value changes across modifiers

## How to Review

Check the added tests in `packages/parser/test/resolver.test.ts` and verify that they pass

---

This is very much an idea open for suggestions 👍 
