### PR TITLE
fix(doc): Update outdated migrate-v2 page

### DIFF
--- a/www/src/pages/docs/0.x/guides/migrating-cobalt.md
+++ b/www/src/pages/docs/0.x/guides/migrating-cobalt.md
@@ -96,7 +96,7 @@ See [the Config docs](/docs/reference/config/) for more info.
 
 Plugins will need to update to [the new Plugin API](/docs/reference/plugin-api/) in order to run. The same basic format is kept, but the plugin hooks have changed and have more features to make working with tokens even easier (hopefully it empowers even better workflows while reducing code!). In a nutshell:
 
-- There’s a new concept of calling `getTransform()` and `setTransform()` to “query” for tokens/modes. This is how plugins share more work than they could before!
+- There’s a new concept of calling `getTransforms()` and `setTransform()` to “query” for tokens/modes. This is how plugins share more work than they could before!
 - The [build() hook](/docs/reference/plugin-api/#build) still builds files, but you should move most of your work into [the new transform() hook](/docs/reference/plugin-api#api)
 - The [new transform() hook](/docs/reference/plugin-api#api) is where you can calculate token values and expose them to other plugins (so long as they query the right `format`)
 - The Linting API has been changed to be simpler and allow for throwing code errors on specific lines/columns.

--- a/www/src/pages/docs/guides/migrating-v2.md
+++ b/www/src/pages/docs/guides/migrating-v2.md
@@ -20,68 +20,48 @@ For plugin authors, a few more changes are necessary. Plugins written in 0.x for
 
 To add resolver functionality:
 
-### Replace Modes with Contexts + Modifiers
+### Add a resolver input and remove the mode property
 
-In most plugins, modes are accessed via `getTransforms()` and `setTransform()`. You’ll need to replace `mode` with `context`, and add a `modifier`:
+In most plugins, modes are accessed via `getTransforms()` and `setTransform()`. You’ll need to replace `mode` with a resolver input:
 
 ```diff
-  transform({ setTransform, resolver }) {
-+   const lightModifier = resolver.source.resolutionOrder.filter((m) => m.type === "modifier" && "light" in m.contexts)?.name || "tzMode";
+  transform({ setTransform }) {
     setTransform(id, {
       // …
 -     mode: "light",
-+     context: "light",
-+     modifier: lightModifier,
++     input: { theme: "light" },
     });
   }
 ```
 
-In most examples, `mode` and `context` are equivalent. But the significant difference here is resolvers allow multiple “namespaces” of contexts via modifiers, so here, we have to do a little more work identifying which is the proper modifier namespace we want to set this in.
+The significant difference with `mode` is that resolvers allow multiple "namespaces" of contexts via modifiers, so here, we have to also specify which modifier the context `light` belongs to, which is `theme`.
 
-Other legacy plugins using modes will be upconverted to a special, internal `tzMode` modifier so that `mode` and `context` operate the same way. However, `tzMode` will never appear in any resolver context, so extra work may be needed if your plugin is trying to handle both 0.x and 2.x formats simultaneously (as in the example, you may want to have it be a fallback).
-
-:::tip
-
-`resolver.source.resolutionOrder` should always be used over `resolver.source.modifiers` for 2 reasons:
-
-1. `resolver.source.modifiers` is optional—the modifier you want may not be present (it may be inlined in `resolutionOrder`).
-2. `resolver.source.resolutionOrder` only contains **used** modifiers, so even if you did find a match in `resolver.source.modifiers`, it may actually be “dead code” that doesn’t affect the final token sets.
-
-Further, everything is normalized, so you don’t have to bother resolving `$ref`s as the work is already done for you.
-
-:::
+Other legacy plugins using modes will be upconverted to a special, internal `tzMode` modifier so that the legacy `mode` and `input` operate the same way. However, `tzMode` will never appear in any resolver context, so extra work may be needed if your plugin is trying to handle both 0.x and 2.x formats simultaneously (as in the example, you may want to have it be a fallback).
 
 #### getTransforms
 
-`getTransforms()` has a minor breaking change: in 0.x, all modes would be returned automatically. But in 2.x, **modifiers and contexts must be explicitly asked for.**:
+`getTransforms()` has a minor breaking change: in 0.x, all modes would be returned automatically. But in 2.x, **a resolver input must be asked for to get a token set for a permutation**:
 
 ```diff
   build({ getTransforms, resolver }) {
-+   const modifiers = [
-+     ...resolver.source.resolutionOrder.filter((m) => m.type === "modifier"),
-+     { "type": "modifier", "name": "tzMode" }, // query for legacy modes, if any
-+   ];
 -   getTransforms({
 -     // …
 -     mode: "light",
 -   });
-+   for (mod of modifiers) {
++   for (input of resolver.listPermutations?.() ?? [{}]) {
 +     getTransforms({
 +       // …
-+       context: "light", // note: if context doesn’t exist, this will return empty array
-+       modifier: mod.name,
++       input,
 +     });
 +   }
   });
 ```
 
-Neither modifier nor context accept glob patterns, and must be an exact match. This means more iteration will be required whenever you require more combinations.
+This means a resolver input is needed for every iteration in order to produce another permutation.
 
-The reason is complexity: in 0.x, legacy modes acted as a single modifier, so the amount of work was usually trivial to calculate everything. But in a resolver where there is no limit to the amount of modifiers, the amount of total work is exponentially increased, to the point calculating everything may be impractical. In some resolvers, this could result in 100× slowdown (or more!), and consumers likely will have many, many permutations they never want calculated.
+The reason is complexity: in 0.x, legacy modes acted as a single modifier, so the amount of work was usually trivial to calculate everything. But in a resolver where there is no limit to the amount of modifiers, the amount of total work is exponentially increased, to the point where calculating everything may be impractical. In some resolvers, this could result in 100× slowdown (or more!), and consumers likely will have many, many permutations they never want calculated.
 
 This is not because resolvers aren’t efficient! On the contrary, they simply allow for more complexity in the system. So it’s a paradigm shift: plugins should only calculate the minimum necessary, and only calculate what has been explicitly asked for.
-
-Also, to help backwards compatibility, **invalid contexts will silently return 0 tokens rather than throw an error.** So it’s safe in `getTransforms()` to ask modifiers for contexts they don’t have; they’ll just return 0 tokens (empty array) without throwing.
 
 ## Migrating from Cobalt 1.0
 
@@ -204,7 +184,7 @@ This lets you incrementally upgrade from legacy modes to new contexts without ha
 
 Plugins will need to update to [the new Plugin API](/docs/reference/plugin-api/) in order to run. The same basic format is kept, but the plugin hooks have changed and have more features to make working with tokens even easier (hopefully it empowers even better workflows while reducing code!). In a nutshell:
 
-- There’s a new concept of calling `getTransform()` and `setTransform()` to “query” for tokens/modes. This is how plugins share more work than they could before!
+- There’s a new concept of calling `getTransforms()` and `setTransform()` to “query” for tokens/modes. This is how plugins share more work than they could before!
 - The [build() hook](/docs/reference/plugin-api/#build) still builds files, but you should move most of your work into [the new transform() hook](/docs/reference/plugin-api#api)
 - The [new transform() hook](/docs/reference/plugin-api#api) is where you can calculate token values and expose them to other plugins (so long as they query the right `format`)
 - The Linting API has been changed to be simpler and allow for throwing code errors on specific lines/columns.


### PR DESCRIPTION
## Changes

Updated the `/docs/guides/migrating-v2` page to reflect correct `setTransform` / `getTransforms` API

## How to Review

Build the doc and check the `/docs/guides/migrating-v2` page 